### PR TITLE
Improve log messages

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,5 @@
 # TexasHoldem.jl
 
-An experimental package for simulating No-Limit Texas Holdem Poker.
+An experimental package for simulating no-limit Texas Holdem Poker.
 
 

--- a/src/player_actions.jl
+++ b/src/player_actions.jl
@@ -70,8 +70,13 @@ function call_valid_amount!(table::Table, player::Player, amt::Real)
     @debug "$(name(player)) calling $(amt)."
     push!(player.action_history, Call(amt))
     player.action_required = false
+    blind_str = is_blind_call(table, player, amt) ? " (blind)" : ""
     contribute!(table, player, amt, true)
-    @info "$(name(player)) called $(amt)."
+    if all_in(player)
+        @info "$(name(player)) called $(amt)$blind_str (now all-in)."
+    else
+        @info "$(name(player)) called $(amt)$blind_str."
+    end
 end
 
 #####

--- a/src/table.jl
+++ b/src/table.jl
@@ -98,6 +98,20 @@ all_all_in_or_folded(table::Table) = all(map(x -> folded(x) || all_in(x), player
 
 blinds(table::Table) = table.blinds
 
+function is_blind_call(table::Table, player::Player, amt = call_amount(table, player))
+    pot_inv = pot_investment(player)
+    @debug "amt = $amt, pot_investment(player) = $pot_inv"
+    bb = blinds(table).big
+    sb = blinds(table).small
+    if is_small_blind(table, player)
+        return amt ≈ sb && pot_inv ≈ sb
+    elseif is_big_blind(table, player)
+        return amt ≈ 0 && pot_inv ≈ bb
+    else
+        return amt ≈ bb && pot_inv ≈ 0
+    end
+end
+
 function reset_round_bank_rolls!(table::Table)
     players = players_at_table(table)
     for player in players

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ local_run = isempty(get(ENV, "CI", ""))
 n_fuzz = local_run ? 10 : 100
 n_fuzz_10_players = local_run ? 1 : 10
 
-tests_to_debug = ["play"]
+tests_to_debug = ["play", "fuzz_play"]
 # tests_to_debug = submodules
 
 for submodule in submodules


### PR DESCRIPTION
Peels off some pieces from #46. This PR
 - improves the log messages and prompts for human play to include call amounts and valid raise bounds.
 - Adds specific messages for assertions