### PR TITLE
Fix 59

### DIFF
--- a/src/player_actions.jl
+++ b/src/player_actions.jl
@@ -70,6 +70,7 @@ function call_valid_amount!(table::Table, player::Player, amt::Real)
     @debug "$(name(player)) calling $(amt)."
     push!(player.action_history, Call(amt))
     player.action_required = false
+    player.checked = false
     blind_str = is_blind_call(table, player, amt) ? " (blind)" : ""
     contribute!(table, player, amt, true)
     if all_in(player)
@@ -189,6 +190,7 @@ function raise_to_valid_raise_amount!(table::Table, player::Player, amt::Real)
     push!(player.action_history, Raise(amt))
     player.action_required = false
     player.last_to_raise = true
+    player.checked = false
     players = players_at_table(table)
     for oponent in players
         oponent.id == player.id && continue

--- a/src/player_options.jl
+++ b/src/player_options.jl
@@ -17,16 +17,18 @@ function player_option!(game::Game, player::Player)
         if bank_roll(player) > call_amt # raise possible
             vrb = valid_raise_bounds(table, player)
             if first(vrb) ≈ last(vrb) # only all-in raise possible
-                player_option!(game, player, game_state, CallAllInFold())
+                option = CallAllInFold()
             else
-                player_option!(game, player, game_state, CallRaiseFold())
+                option = CallRaiseFold()
             end
         else # only all-in possible
-            player_option!(game, player, game_state, CallFold())
+            option = CallFold()
         end
     else
-        player_option!(game, player, game_state, CheckRaiseFold())
+        option = CheckRaiseFold()
     end
+    @debug "option = $option"
+    player_option!(game, player, game_state, option)
 end
 
 #####

--- a/test/game.jl
+++ b/test/game.jl
@@ -42,10 +42,12 @@ end
 
     # Round 3
     raise_to!(game, players[1], 10)
+    @test TH.checked(players[1]) == false
     call!(game, players[2])
 
     # Round 4
     raise_to!(game, players[1], 20)
+    @test TH.checked(players[1]) == false
     fold!(game, players[2])
 
     # All-in cases
@@ -62,6 +64,7 @@ end
 
     # Round 2
     raise_to!(game, players[1], players[1].bank_roll)
+    @test TH.checked(players[1]) == false
     call!(game, players[2])
 
     @test_throws AssertionError raise_to!(game, players[1], 10000) # raise exceeds bank roll!


### PR DESCRIPTION
Running in debug mode (over 1k games) revealed that `all_checked_or_folded(table)` was returning true even when a player raised, which meant that it needed to be flipped after `raise_to!` and `call!`.

Closes #59.