### PR TITLE
Rename player id -> seat number.

### DIFF
--- a/src/config_game.jl
+++ b/src/config_game.jl
@@ -90,19 +90,19 @@ function configure_human_players(n_players)
     choices = request("Select which players are human:", menu)
     println("$(length(choices)) human players ($(join(sort(collect(choices)), ", ")))")
     length(choices) > 0 || println("Menu canceled.")
-    human_player_ids = collect(choices)
-    return human_player_ids
+    human_seat_numbers = collect(choices)
+    return human_seat_numbers
 end
 
 function configure_custom_game()
 
     n_players = cofigure_n_players()
     blinds = cofigure_blinds()
-    human_player_ids = configure_human_players(n_players)
+    human_seat_numbers = configure_human_players(n_players)
     bank_roll = cofigure_bank_roll(blinds)
 
     players = ntuple(n_players) do i
-        if i in human_player_ids
+        if i in human_seat_numbers
             Player(Human(), i; bank_roll=bank_roll)
         else
             Player(ai_to_use(), i; bank_roll=bank_roll)

--- a/src/game.jl
+++ b/src/game.jl
@@ -17,7 +17,8 @@ function Base.show(io::IO, game::Game)
     println(io, "-----------------------")
 end
 
-function Game(players::Tuple;
+function Game(
+        players::Tuple;
         deck = ordered_deck(),
         table = nothing,
         button_id::Int = button_id(),
@@ -80,8 +81,8 @@ reset_round_bank_rolls!(game::Game, state::AbstractGameState) = reset_round_bank
 function act_generic!(game::Game, state::AbstractGameState)
     table = game.table
     table.winners.declared && return
-    set_state!(game.table, state)
-    print_new_cards(game.table, state)
+    set_state!(table, state)
+    print_new_cards(table, state)
     reset_round_bank_rolls!(game, state)
 
     any_actions_required(game) || return

--- a/src/player_actions.jl
+++ b/src/player_actions.jl
@@ -193,7 +193,7 @@ function raise_to_valid_raise_amount!(table::Table, player::Player, amt::Real)
     player.checked = false
     players = players_at_table(table)
     for oponent in players
-        oponent.id == player.id && continue
+        seat_number(oponent) == seat_number(player) && continue
         folded(oponent) && continue
         oponent.action_required = true
         oponent.last_to_raise = false

--- a/src/player_types.jl
+++ b/src/player_types.jl
@@ -17,7 +17,7 @@ ai_to_use() = Bot5050()
 
 mutable struct Player{LF}
     life_form::LF
-    id::Int
+    seat_number::Int
     cards::Union{Nothing,Tuple{<:Card,<:Card}}
     bank_roll::Float64
     action_history::Vector
@@ -37,7 +37,7 @@ function Base.show(io::IO, player::Player, include_type = true)
     println(io, "$(name(player))        = $(player.cards)")
 end
 
-function Player(life_form, id, cards = nothing; bank_roll = 200)
+function Player(life_form, seat_number, cards = nothing; bank_roll = 200)
     action_history = []
     action_required = true
     all_in = false
@@ -50,7 +50,7 @@ function Player(life_form, id, cards = nothing; bank_roll = 200)
     last_to_raise = false
     args = (
         life_form,
-        id,
+        seat_number,
         cards,
         Float64(bank_roll),
         action_history,
@@ -69,8 +69,8 @@ end
 
 cards(player::Player) = player.cards
 bank_roll(player::Player) = player.bank_roll
-player_id(player::Player) = player.id
-name(player::Player{LF}) where {LF <: AbstractLifeForm} = "$(nameof(LF))[$(player.id)]"
+seat_number(player::Player) = player.seat_number
+name(player::Player{LF}) where {LF <: AbstractLifeForm} = "$(nameof(LF))[$(seat_number(player))]"
 folded(player::Player) = player.folded
 still_playing(player::Player) = !player.folded
 action_history(player::Player) = player.action_history

--- a/src/table.jl
+++ b/src/table.jl
@@ -171,7 +171,7 @@ Player position, given
  - `relative::Int = 0` the relative location to the player
 """
 position(table, player::Player, relative=0) =
-    mod(relative + player.id - 1, length(table.players))+1
+    mod(relative + seat_number(player) - 1, length(table.players))+1
 
 """
     circle_table(n_players, button_id, state)
@@ -192,9 +192,9 @@ small_blind(table::Table) = players_at_table(table)[circle_table(table, 2)]
 big_blind(table::Table) = players_at_table(table)[circle_table(table, 3)]
 first_to_act(table::Table) = players_at_table(table)[circle_table(table, 4)]
 
-is_small_blind(table::Table, player::Player) = player.id == small_blind(table).id
-is_big_blind(table::Table, player::Player) = player.id == big_blind(table).id
-is_first_to_act(table::Table, player::Player) = player.id == first_to_act(table).id
+is_small_blind(table::Table, player::Player) = seat_number(player) == seat_number(small_blind(table))
+is_big_blind(table::Table, player::Player) = seat_number(player) == seat_number(big_blind(table))
+is_first_to_act(table::Table, player::Player) = seat_number(player) == seat_number(first_to_act(table))
 
 any_actions_required(table::Table) = any(action_required.(players_at_table(table)))
 
@@ -230,7 +230,7 @@ Base.iterate(ct::CircleTable{FirstToAct}, state = 4) =
     (ct.players[circle_table(ct.n_players, ct.button_id, state)], state+1)
 
 Base.iterate(ct::CircleTable{P}, state = 1) where {P <: Player} =
-    (ct.players[circle_table(ct.n_players, ct.player.id, state)], state+1)
+    (ct.players[circle_table(ct.n_players, seat_number(ct.player), state)], state+1)
 
 #####
 ##### Deal

--- a/test/table.jl
+++ b/test/table.jl
@@ -2,6 +2,7 @@ using Test
 using PlayingCards
 using Logging
 using TexasHoldem
+using TexasHoldem: seat_number
 TH = TexasHoldem
 
 @testset "Table: constructors / observed cards" begin
@@ -96,7 +97,7 @@ end
     state = 0
     for player in TH.circle(table, Button())
         state+=1
-        @test player.id == state
+        @test seat_number(player) == state
         state == length(players) && break
     end
     @test state==length(players)
@@ -108,11 +109,11 @@ end
     state = 0
     for player in TH.circle(table, Button())
         state+=1
-        state == 1 && @test player.id == 2
-        state == 2 && @test player.id == 3
-        state == 3 && @test player.id == 4
-        state == 4 && @test player.id == 5
-        state == 5 && @test player.id == 1
+        state == 1 && @test seat_number(player) == 2
+        state == 2 && @test seat_number(player) == 3
+        state == 3 && @test seat_number(player) == 4
+        state == 4 && @test seat_number(player) == 5
+        state == 5 && @test seat_number(player) == 1
         state == length(players) && break
     end
     @test state==length(players)
@@ -130,11 +131,11 @@ end
     state = 0
     for player in TH.circle(table, SmallBlind())
         state+=1
-        state == 1 && @test player.id == 2
-        state == 2 && @test player.id == 3
-        state == 3 && @test player.id == 4
-        state == 4 && @test player.id == 5
-        state == 5 && @test player.id == 1
+        state == 1 && @test seat_number(player) == 2
+        state == 2 && @test seat_number(player) == 3
+        state == 3 && @test seat_number(player) == 4
+        state == 4 && @test seat_number(player) == 5
+        state == 5 && @test seat_number(player) == 1
         state == length(players) && break
     end
     @test state==length(players)
@@ -146,11 +147,11 @@ end
     state = 0
     for player in TH.circle(table, SmallBlind())
         state+=1
-        state == 1 && @test player.id == 3
-        state == 2 && @test player.id == 4
-        state == 3 && @test player.id == 5
-        state == 4 && @test player.id == 1
-        state == 5 && @test player.id == 2
+        state == 1 && @test seat_number(player) == 3
+        state == 2 && @test seat_number(player) == 4
+        state == 3 && @test seat_number(player) == 5
+        state == 4 && @test seat_number(player) == 1
+        state == 5 && @test seat_number(player) == 2
         state == length(players) && break
     end
     @test state==length(players)
@@ -168,11 +169,11 @@ end
     state = 0
     for player in TH.circle(table, BigBlind())
         state+=1
-        state == 1 && @test player.id == 3
-        state == 2 && @test player.id == 4
-        state == 3 && @test player.id == 5
-        state == 4 && @test player.id == 1
-        state == 5 && @test player.id == 2
+        state == 1 && @test seat_number(player) == 3
+        state == 2 && @test seat_number(player) == 4
+        state == 3 && @test seat_number(player) == 5
+        state == 4 && @test seat_number(player) == 1
+        state == 5 && @test seat_number(player) == 2
         state == length(players) && break
     end
     @test state==length(players)
@@ -184,11 +185,11 @@ end
     state = 0
     for player in TH.circle(table, BigBlind())
         state+=1
-        state == 1 && @test player.id == 4
-        state == 2 && @test player.id == 5
-        state == 3 && @test player.id == 1
-        state == 4 && @test player.id == 2
-        state == 5 && @test player.id == 3
+        state == 1 && @test seat_number(player) == 4
+        state == 2 && @test seat_number(player) == 5
+        state == 3 && @test seat_number(player) == 1
+        state == 4 && @test seat_number(player) == 2
+        state == 5 && @test seat_number(player) == 3
         state == length(players) && break
     end
     @test state==length(players)
@@ -206,11 +207,11 @@ end
     state = 0
     for player in TH.circle(table, FirstToAct())
         state+=1
-        state == 1 && @test player.id == 4
-        state == 2 && @test player.id == 5
-        state == 3 && @test player.id == 1
-        state == 4 && @test player.id == 2
-        state == 5 && @test player.id == 3
+        state == 1 && @test seat_number(player) == 4
+        state == 2 && @test seat_number(player) == 5
+        state == 3 && @test seat_number(player) == 1
+        state == 4 && @test seat_number(player) == 2
+        state == 5 && @test seat_number(player) == 3
         state == length(players) && break
     end
     @test state==length(players)
@@ -222,11 +223,11 @@ end
     state = 0
     for player in TH.circle(table, FirstToAct())
         state+=1
-        state == 1 && @test player.id == 5
-        state == 2 && @test player.id == 1
-        state == 3 && @test player.id == 2
-        state == 4 && @test player.id == 3
-        state == 5 && @test player.id == 4
+        state == 1 && @test seat_number(player) == 5
+        state == 2 && @test seat_number(player) == 1
+        state == 3 && @test seat_number(player) == 2
+        state == 4 && @test seat_number(player) == 3
+        state == 5 && @test seat_number(player) == 4
         state == length(players) && break
     end
     @test state==length(players)
@@ -242,7 +243,7 @@ end
     state = 0
     for player in TH.circle(table, players[1])
         state+=1
-        @test player.id == state
+        @test seat_number(player) == state
         state == length(players) && break
     end
     @test state==length(players)
@@ -254,7 +255,7 @@ end
     state = 0
     for player in TH.circle(table, players[1])
         state+=1
-        @test player.id == state
+        @test seat_number(player) == state
         state == length(players) && break
     end
     @test state==length(players)
@@ -266,11 +267,11 @@ end
     state = 0
     for player in TH.circle(table, players[2])
         state+=1
-        state == 1 && @test player.id == 2
-        state == 2 && @test player.id == 3
-        state == 3 && @test player.id == 4
-        state == 4 && @test player.id == 5
-        state == 5 && @test player.id == 1
+        state == 1 && @test seat_number(player) == 2
+        state == 2 && @test seat_number(player) == 3
+        state == 3 && @test seat_number(player) == 4
+        state == 4 && @test seat_number(player) == 5
+        state == 5 && @test seat_number(player) == 1
         state == length(players) && break
     end
     @test state==length(players)
@@ -282,11 +283,11 @@ end
     state = 0
     for player in TH.circle(table, players[2])
         state+=1
-        state == 1 && @test player.id == 2
-        state == 2 && @test player.id == 3
-        state == 3 && @test player.id == 4
-        state == 4 && @test player.id == 5
-        state == 5 && @test player.id == 1
+        state == 1 && @test seat_number(player) == 2
+        state == 2 && @test seat_number(player) == 3
+        state == 3 && @test seat_number(player) == 4
+        state == 4 && @test seat_number(player) == 5
+        state == 5 && @test seat_number(player) == 1
         state == length(players) && break
     end
     @test state==length(players)

--- a/test/transactions.jl
+++ b/test/transactions.jl
@@ -12,7 +12,7 @@ TH = TexasHoldem
     )
     tm = TH.TransactionManager(players)
     table = Table(;players=players,cards=table_cards,transactions=tm)
-    @test TH.player_id.(tm.side_pots) == [1,2,3]
+    @test TH.seat_number.(tm.side_pots) == [1,2,3]
 
     TH.raise_to!(table, players[1], 100) # raise all-in
     TH.call!(table, players[2]) # call


### PR DESCRIPTION
In preparation for adding `tournament!` support, we need to be able to remove players from the table, move them around, and still be able to identify which player wins a tournament.

A simple solution might be to initially set `player.folded = true` for any players with 0 bank rolls.