### PR TITLE
Add tournament-style play

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
           - '1.4'
           - '1.5'
           - '1.6.0'

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
 version = "0.1.0"
 
 [deps]
-Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 PlayingCards = "ecfe714a-bcc2-4d11-ad00-25525ff8f984"
 PokerHandEvaluator = "18ed25b1-892a-4a3b-b8fc-1036dc9a6a89"
@@ -14,4 +13,4 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 [compat]
 PlayingCards = "0.2"
 PokerHandEvaluator = "0.1"
-julia = "1.3"
+julia = "1.4"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 PlayingCards = "ecfe714a-bcc2-4d11-ad00-25525ff8f984"
 PokerHandEvaluator = "18ed25b1-892a-4a3b-b8fc-1036dc9a6a89"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Games can be played with:
 
 ```julia
 using TexasHoldem
-play(configure_game())
+play!(configure_game())
 ```
 
 # Creating your own bot
@@ -108,5 +108,5 @@ function TH.player_option!(game::Game, player::Player{MyBot}, ::AbstractGameStat
 end
 
 # Heads-up against the MyBot!
-play(Game((Player(Human(), 1), Player(MyBot(), 2))))
+play!(Game((Player(Human(), 1), Player(MyBot(), 2))))
 ```

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,4 @@
 status = [
-  "ci 1.3 - ubuntu-latest",
-  "ci 1.3 - windows-latest",
-  "ci 1.3 - macOS-latest",
   "ci 1.4 - ubuntu-latest",
   "ci 1.4 - windows-latest",
   "ci 1.4 - macOS-latest",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -4,5 +4,6 @@
 TexasHoldem
 TexasHoldem.raise_to!
 TexasHoldem.move_button!
-TexasHoldem.play
+TexasHoldem.play!
+TexasHoldem.tournament!
 ```

--- a/src/TexasHoldem.jl
+++ b/src/TexasHoldem.jl
@@ -14,6 +14,7 @@ A no-limit Texas Holdem simulator.
 module TexasHoldem
 
 using PlayingCards
+using Accessors
 using PokerHandEvaluator
 using PokerHandEvaluator.HandTypes
 using Printf

--- a/src/TexasHoldem.jl
+++ b/src/TexasHoldem.jl
@@ -14,7 +14,6 @@ A no-limit Texas Holdem simulator.
 module TexasHoldem
 
 using PlayingCards
-using Accessors
 using PokerHandEvaluator
 using PokerHandEvaluator.HandTypes
 using Printf

--- a/src/config_game.jl
+++ b/src/config_game.jl
@@ -64,9 +64,7 @@ function configure_basic_heads_up_game()
         Player(Human(), 1; bank_roll=bank_roll),
         Player(ai_to_use(), 2; bank_roll=bank_roll)
     )
-    return Game(players;
-        blinds=blinds,
-    )
+    return Game(players; blinds=blinds)
 end
 
 function configure_basic_1v4_game()
@@ -79,9 +77,29 @@ function configure_basic_1v4_game()
         Player(ai_to_use(), 4; bank_roll=bank_roll),
         Player(ai_to_use(), 5; bank_roll=bank_roll),
     )
-    return Game(players;
-        blinds=blinds,
+    return Game(players; blinds=blinds)
+end
+
+function configure_basic_2_bots_game()
+    bank_roll = 100
+    blinds = Blinds(1, 2)
+    players = (
+        Player(ai_to_use(), 1; bank_roll=bank_roll),
+        Player(ai_to_use(), 2; bank_roll=bank_roll),
     )
+    return Game(players; blinds=blinds)
+end
+
+function configure_basic_4_bots_game()
+    bank_roll = 100
+    blinds = Blinds(1, 2)
+    players = (
+        Player(ai_to_use(), 1; bank_roll=bank_roll),
+        Player(ai_to_use(), 2; bank_roll=bank_roll),
+        Player(ai_to_use(), 3; bank_roll=bank_roll),
+        Player(ai_to_use(), 4; bank_roll=bank_roll),
+    )
+    return Game(players; blinds=blinds)
 end
 
 function configure_human_players(n_players)
@@ -89,7 +107,7 @@ function configure_human_players(n_players)
     menu = MultiSelectMenu(options) # charset=:unicode is not supported in earlier Julia versions
     choices = request("Select which players are human:", menu)
     println("$(length(choices)) human players ($(join(sort(collect(choices)), ", ")))")
-    length(choices) > 0 || println("Menu canceled.")
+    length(choices) > 0 || println("No human players.")
     human_seat_numbers = collect(choices)
     return human_seat_numbers
 end
@@ -114,16 +132,20 @@ end
 
 function configure_game()
     options = [
-        "Heads up-- you vs AI, \$1-\$2 blinds, \$100 bank roll",
-        "1v4-- you vs 4 AI, \$1-\$2 blinds, \$100 bank roll",
-        "custom game"
+        "1) Heads up-- you vs AI, \$1-\$2 blinds, \$100 bank roll",
+        "2) 1v4-- you vs 4 AI, \$1-\$2 blinds, \$100 bank roll",
+        "3) 2 bots!, \$1-\$2 blinds, \$100 bank roll",
+        "4) 4 bots!, \$1-\$2 blinds, \$100 bank roll",
+        "5) custom game"
     ]
     menu = RadioMenu(options, pagesize=4)
     choice = request("Configure game:", menu)
     if choice != -1
-        choice == 3 && return configure_custom_game()
-        choice == 2 && return configure_basic_1v4_game()
         choice == 1 && return configure_basic_heads_up_game()
+        choice == 2 && return configure_basic_1v4_game()
+        choice == 3 && return configure_basic_2_bots_game()
+        choice == 4 && return configure_basic_4_bots_game()
+        choice == 5 && return configure_custom_game()
         error("Uncaught case")
     else
         println("Menu canceled.")

--- a/src/config_game.jl
+++ b/src/config_game.jl
@@ -134,5 +134,5 @@ export configure_play_game
 function configure_play_game()
     # game = configure_game()
     game = configure_basic_heads_up_game()
-    play(game)
+    play!(game)
 end

--- a/src/player_options.jl
+++ b/src/player_options.jl
@@ -36,7 +36,10 @@ function player_option!(game::Game, player::Player)
     call_amt = call_amount(table, player)
     game_state = state(table)
     if !(call_amt ≈ 0) # must call to stay in
-        if bank_roll(player) > call_amt # raise possible
+        cond_1 = bank_roll(player) > call_amt
+        cond_2 = an_opponent_can_call_a_raise(table, player)
+        raise_possible = cond_1 && cond_2
+        if raise_possible # raise possible
             vrb = valid_raise_bounds(table, player)
             if first(vrb) ≈ last(vrb) # only all-in raise possible
                 option = CallAllInFold()
@@ -117,15 +120,15 @@ end
 function input_raise_amt(table, player::Player{Human}, io::IO=stdin)
     raise_amt = nothing
     while true
-        println(io, "Enter raise amt:")
+        println(io, "Enter raise amt:") # TODO: io only works for tests, but does not for user input
         raise_amt = readline(io)
         try
             raise_amt = parse(Float64, raise_amt)
             is_valid, msg = is_valid_raise_amount(table, player, raise_amt)
             is_valid && break
-            println(io, msg)
+            println(io, msg) # TODO: io only works for tests, but does not for user input
         catch
-            println(io, "Raise must be a Float64")
+            println(io, "Raise must be a Float64") # TODO: io only works for tests, but does not for user input
         end
     end
     @assert raise_amt ≠ nothing

--- a/src/player_options.jl
+++ b/src/player_options.jl
@@ -117,18 +117,23 @@ function player_option!(game::Game, player::Player{Human}, ::AbstractGameState, 
     choice == 2 && fold!(game, player)
 end
 
+# io only works for tests, but does not for user input
+# so we have a switch for the test suite
+use_input_io() = false
+println_io(io::IO, msg) = use_input_io() ? println(io, msg) : println(msg)
+
 function input_raise_amt(table, player::Player{Human}, io::IO=stdin)
     raise_amt = nothing
     while true
-        println(io, "Enter raise amt:") # TODO: io only works for tests, but does not for user input
+        println_io(io, "Enter raise amt:")
         raise_amt = readline(io)
         try
             raise_amt = parse(Float64, raise_amt)
             is_valid, msg = is_valid_raise_amount(table, player, raise_amt)
             is_valid && break
-            println(io, msg) # TODO: io only works for tests, but does not for user input
+            println_io(io, msg)
         catch
-            println(io, "Raise must be a Float64") # TODO: io only works for tests, but does not for user input
+            println_io(io, "Raise must be a Float64")
         end
     end
     @assert raise_amt ≠ nothing

--- a/src/player_types.jl
+++ b/src/player_types.jl
@@ -23,7 +23,7 @@ mutable struct Player{LF}
     action_history::Vector
     action_required::Bool
     all_in::Bool
-    round_bank_roll::Float64
+    round_bank_roll::Float64 # bank roll at the beginning of the round
     folded::Bool
     pot_investment::Float64 # accumulation of round_contribution, TODO: needs to be added to reset_game!
     checked::Bool

--- a/src/transactions.jl
+++ b/src/transactions.jl
@@ -58,13 +58,11 @@ amount(tm::TransactionManager) = amount(tm.side_pots[tm.pot_id[1]])
 cap(tm::TransactionManager) = cap(tm.side_pots[tm.pot_id[1]])
 
 function last_action_of_round(table, player, call)
-    for (i,oponent) in enumerate(circle(table, player))
-        seat_number(oponent) == seat_number(player) && continue
-        folded(oponent) && continue
-        all_in(oponent) && !last_to_raise(oponent) && continue
-        return last_to_raise(oponent) && call
-        i > length(players_at_table(table)) && error("Broken logic in last_action_of_round")
-    end
+    @debug "Determining last_action_of_round"
+    @debug "    action_required.(players_at_table(table)) = $(action_required.(players_at_table(table)))"
+    @debug "    all_oppononents_all_in(table, player) = $(all_oppononents_all_in(table, player))"
+    @debug "    call = $call"
+    return all_oppononents_all_in(table, player) || (count(action_required.(players_at_table(table))) == 0 && call)
 end
 
 """
@@ -138,6 +136,7 @@ function contribute!(table, player, amt, call=false)
 
     if bank_roll(player) ≈ 0 # went all-in, set exactly.
         player.all_in = true
+        player.action_required = false
         player.bank_roll = 0
     end
 

--- a/test/fuzz_play.jl
+++ b/test/fuzz_play.jl
@@ -1,16 +1,27 @@
 using Test
 using PlayingCards
 using TexasHoldem
-TH = TexasHoldem
 
-@testset "Game: Play (3 Bot5050's)" begin
+@testset "Game: play! (3 Bot5050's)" begin
     for n in 1:n_fuzz
         play!(Game(ntuple(i->Player(Bot5050(), i), 3)))
     end
 end
 
-@testset "Game: Play (10 Bot5050's)" begin
+@testset "Game: play! (10 Bot5050's)" begin
     for n in 1:n_fuzz_10_players
         play!(Game(ntuple(i->Player(Bot5050(), i), 10)))
+    end
+end
+
+@testset "Game: tournament! (2 Bot5050's)" begin
+    for n in 1:n_fuzz
+        tournament!(Game(ntuple(i->Player(Bot5050(), i; bank_roll = 6), 2)))
+    end
+end
+
+@testset "Game: tournament! (10 Bot5050's)" begin
+    for n in 1:n_fuzz_10_players
+        tournament!(Game(ntuple(i->Player(Bot5050(), i; bank_roll = 6), 10)))
     end
 end

--- a/test/fuzz_play.jl
+++ b/test/fuzz_play.jl
@@ -5,12 +5,12 @@ TH = TexasHoldem
 
 @testset "Game: Play (3 Bot5050's)" begin
     for n in 1:n_fuzz
-        play(Game(ntuple(i->Player(Bot5050(), i), 3)))
+        play!(Game(ntuple(i->Player(Bot5050(), i), 3)))
     end
 end
 
 @testset "Game: Play (10 Bot5050's)" begin
     for n in 1:n_fuzz_10_players
-        play(Game(ntuple(i->Player(Bot5050(), i), 10)))
+        play!(Game(ntuple(i->Player(Bot5050(), i), 10)))
     end
 end

--- a/test/human_player_option.jl
+++ b/test/human_player_option.jl
@@ -2,6 +2,7 @@ using Test
 using REPL.TerminalMenus
 using PlayingCards
 using TexasHoldem
+import TexasHoldem
 TH = TexasHoldem
 
 function simulate_keystrokes(keys...)
@@ -84,6 +85,7 @@ these tests. We can't seem to, however.
    so we need to use TerminalRegressionTests.
 =#
 
+TH.use_input_io() = true
 @static if !Sys.iswindows()
     using TerminalRegressionTests
     TRT = TerminalRegressionTests
@@ -123,4 +125,5 @@ these tests. We can't seem to, however.
         end
     end
 end
+TH.use_input_io() = false
 

--- a/test/play.jl
+++ b/test/play.jl
@@ -12,21 +12,21 @@ include("tester_bots.jl")
 end
 
 @testset "Game: Play (BotCheckCall)" begin
-    play(Game(ntuple(i->Player(BotCheckCall(), i), 3)))
+    play!(Game(ntuple(i->Player(BotCheckCall(), i), 3)))
 end
 
 @testset "Game: Play (BotCheckFold)" begin
-    play(Game(ntuple(i->Player(BotCheckFold(), i), 3)))
+    play!(Game(ntuple(i->Player(BotCheckFold(), i), 3)))
 end
 
 @testset "Game: Play (BotBetSB) - breaks lowest allowable bet" begin
     game = Game((Player(BotBetSB(),1), Player(BotCheckCall(),2)))
     # Cannot raise small blind on pre-flop, must raise at least big-blind
-    @test_throws AssertionError("Raise must be between [\$4.0, \$200.0]") play(game)
+    @test_throws AssertionError("Raise must be between [\$4.0, \$200.0]") play!(game)
 end
 
 @testset "Game: Play (BotBetBB)" begin
-    play(Game((Player(BotBetBB(), 1), Player(BotCheckCall(), 2),)))
+    play!(Game((Player(BotBetBB(), 1), Player(BotCheckCall(), 2),)))
 end
 
 struct NoActionBot <: AbstractAI end
@@ -35,30 +35,30 @@ TH.player_option!(game::Game, player::Player{NoActionBot}, ::AbstractGameState, 
 
 @testset "Game: Play (NoActionBot)" begin
     game = Game((Player(BotCheckCall(), 1), Player(NoActionBot(), 2),))
-    @test_throws AssertionError("Must take exactly 1 action.") play(game)
+    @test_throws AssertionError("Must take exactly 1 action.") play!(game)
 end
 
 @testset "Non-valid option using BotCheckOnCallRaiseFold" begin
     game = Game((Player(BotCheckCall(), 1), Player(BotCheckOnCallRaiseFold(), 2),))
-    @test_throws ErrorException("Cannot check. Available options: CallRaiseFold") play(game)
+    @test_throws ErrorException("Cannot check. Available options: CallRaiseFold") play!(game)
 end
 @testset "Non-valid option using BotCheckOnCallAllInFold" begin
     game = Game((Player(BotCheckOnCallAllInFold(), 1), Player(BotRaiseAlmostAllIn(), 2)))
-    @test_throws ErrorException("Cannot check. Available options: CallAllInFold") play(game)
+    @test_throws ErrorException("Cannot check. Available options: CallAllInFold") play!(game)
 end
 @testset "Non-valid option using BotCheckOnCallFold" begin
     game = Game((Player(BotCheckOnCallFold(), 1), Player(BotRaiseAllIn(), 2)))
-    @test_throws ErrorException("Cannot check. Available options: CallFold") play(game)
+    @test_throws ErrorException("Cannot check. Available options: CallFold") play!(game)
 end
 @testset "Non-valid option using BotCallOnCheckRaiseFold" begin
     game = Game((Player(BotCheckCall(), 1), Player(BotCallOnCheckRaiseFold(), 2),))
     # We catch this incorrect option error before it's completed,
     # so we can't error in `validate_action`
-    # @test_throws ErrorException("Cannot call. Available options: CheckRaiseFold") play(game)
-    @test_throws AssertionError("Cannot contribute \$0.0 to the pot!") play(game)
+    # @test_throws ErrorException("Cannot call. Available options: CheckRaiseFold") play!(game)
+    @test_throws AssertionError("Cannot contribute \$0.0 to the pot!") play!(game)
 end
 @testset "Non-valid option using BotRaiseOnCallFold" begin
     game = Game((Player(BotRaiseOnCallFold(), 1), Player(BotRaiseAllIn(), 2)))
-    @test_throws AssertionError("Only allowable raise is \$200.0 (all-in)") play(game)
+    @test_throws AssertionError("Only allowable raise is \$200.0 (all-in)") play!(game)
 end
 

--- a/test/play.jl
+++ b/test/play.jl
@@ -59,6 +59,12 @@ end
 end
 @testset "Non-valid option using BotRaiseOnCallFold" begin
     game = Game((Player(BotRaiseOnCallFold(), 1), Player(BotRaiseAllIn(), 2)))
-    @test_throws AssertionError("Only allowable raise is \$200.0 (all-in)") play!(game)
+    @test_throws AssertionError("Cannot raise 0.") play!(game)
+end
+
+@testset "Player limps all in" begin
+    # Note that the order of the players seems to be important here.
+    game = Game((Player(BotCheckCall(), 2; bank_roll = 11), Player(BotLimpAllIn(), 1; bank_roll = 1)))
+    play!(game)
 end
 

--- a/test/tester_bots.jl
+++ b/test/tester_bots.jl
@@ -2,6 +2,9 @@
 ##### Tester bots
 #####
 
+using TexasHoldem
+import TexasHoldem
+TH = TexasHoldem
 const AGS = AbstractGameState
 
 ##### BotCheckFold
@@ -88,3 +91,8 @@ TH.player_option!(game::Game, player::Player{BotCallOnCheckRaiseFold}, ::AGS, ::
 struct BotRaiseOnCallFold <: AbstractAI end
 
 TH.player_option!(game::Game, player::Player{BotRaiseOnCallFold}, ::AGS, ::CallFold) = raise_to!(game, player, bank_roll(player))
+
+##### BotLimpAllIn
+struct BotLimpAllIn <: AbstractAI end
+
+TH.player_option!(game::Game, player::Player{BotLimpAllIn}, ::AGS, ::PlayerOptions) = call!(game, player)


### PR DESCRIPTION
 - Adds a preliminary version of tournament-style play.
 - Removes support for julia 1.3 because `filter` doesn't seem to work on `Tuple`s. This isn't a major reason, but I'd prefer to avoid `collect`'s for all uses of `filter` just to support 1.3.

Right now, we just set `player.folded = true` for losing players. We may want to remove players this will require some changes to how the transaction manager work. This will hopefully just require a simple map from seat numbers to remaining players.