### PR TITLE
Improve iterators

### DIFF
--- a/test/table.jl
+++ b/test/table.jl
@@ -67,259 +67,123 @@ end
     @test TH.buttons(table.buttons) == (1, 3, 1, 3)
 end
 
-@testset "Table: Circle table" begin
-    @test TH.circle_table(5, 1, 1) == 1
-    @test TH.circle_table(5, 1, 2) == 2
-    @test TH.circle_table(5, 1, 3) == 3
-    @test TH.circle_table(5, 1, 4) == 4
-    @test TH.circle_table(5, 1, 5) == 5
-
-    @test TH.circle_table(5, 4, 1) == 4
-    @test TH.circle_table(5, 4, 2) == 5
-    @test TH.circle_table(5, 4, 3) == 1
-    @test TH.circle_table(5, 4, 4) == 2
-    @test TH.circle_table(5, 4, 5) == 3
-
-    @test TH.circle_table(2, 1, 1) == 1
-    @test TH.circle_table(2, 1, 2) == 2
-
-    @test TH.circle_table(2, 2, 1) == 2
-    @test TH.circle_table(2, 2, 2) == 1
+@testset "Table: Circle index" begin
+    @test TH.circle_index(5, 1) == 1
+    @test TH.circle_index(5, 2) == 2
+    @test TH.circle_index(5, 3) == 3
+    @test TH.circle_index(5, 4) == 4
+    @test TH.circle_index(5, 5) == 5
+    @test TH.circle_index(5, 6) == 1
+    @test TH.circle_index(5, 7) == 2
+    @test TH.circle_index(5, 0) == 5
+    @test TH.circle_index(5, -1) == 4
 end
 
-@testset "Table: player position" begin
-    players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players, dealer_id = TH.default_dealer_id())
-
-    @test TH.position(table, players[1], -5) == 1
-    @test TH.position(table, players[1], -4) == 2
-    @test TH.position(table, players[1], -3) == 3
-    @test TH.position(table, players[1], -2) == 4
-    @test TH.position(table, players[1], -1) == 5
-    @test TH.position(table, players[1], 0) == 1
-    @test TH.position(table, players[1], 1) == 2
-    @test TH.position(table, players[1], 2) == 3
-    @test TH.position(table, players[1], 3) == 4
-    @test TH.position(table, players[1], 4) == 5
-    @test TH.position(table, players[1], 5) == 1
-
-    @test TH.position(table, players[2], -5) == 2
-    @test TH.position(table, players[2], -4) == 3
-    @test TH.position(table, players[2], -3) == 4
-    @test TH.position(table, players[2], -2) == 5
-    @test TH.position(table, players[2], -1) == 1
-    @test TH.position(table, players[2], 0) == 2
-    @test TH.position(table, players[2], 1) == 3
-    @test TH.position(table, players[2], 2) == 4
-    @test TH.position(table, players[2], 3) == 5
-    @test TH.position(table, players[2], 4) == 1
-    @test TH.position(table, players[2], 5) == 2
-end
-
-@testset "Table: Button iterator" begin
-
+@testset "Table: Dealer iterator" begin
     @test TH.default_dealer_id() == 1
 
-    players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players, dealer_id = TH.default_dealer_id())
-    TH.deal!(table, TH.blinds(table))
-
     # dealer_id = 1
-    state = 0
-    for player in TH.circle(table, Button())
-        state+=1
-        @test seat_number(player) == state
-        state == length(players) && break
-    end
-    @test state==length(players)
+    players = ntuple(i-> Player(Bot5050(), i), 5)
+    table = Table(;players = players)
+    TH.deal!(table, TH.blinds(table))
+    iter_players = collect(TH.circle(table, Dealer(), length(players)))
+    sn = seat_number.(iter_players)
+    @test sn == [1, 2, 3, 4, 5]
 
-    # dealer_id = 2
+    dealer_id = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(;players = players, dealer_id = 2)
     TH.deal!(table, TH.blinds(table))
-    state = 0
-    for player in TH.circle(table, Button())
-        state+=1
-        state == 1 && @test seat_number(player) == 2
-        state == 2 && @test seat_number(player) == 3
-        state == 3 && @test seat_number(player) == 4
-        state == 4 && @test seat_number(player) == 5
-        state == 5 && @test seat_number(player) == 1
-        state == length(players) && break
-    end
-    @test state==length(players)
+    iter_players = collect(TH.circle(table, Dealer(), length(players)))
+    sn = seat_number.(iter_players)
+    @test sn == [2, 3, 4, 5, 1]
 end
 
 @testset "Table: SmallBlind iterator" begin
-
-    @test TH.default_dealer_id() == 1
-
-    players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players, dealer_id = TH.default_dealer_id())
-    TH.deal!(table, TH.blinds(table))
-
     # dealer_id = 1
-    state = 0
-    for player in TH.circle(table, SmallBlind())
-        state+=1
-        state == 1 && @test seat_number(player) == 2
-        state == 2 && @test seat_number(player) == 3
-        state == 3 && @test seat_number(player) == 4
-        state == 4 && @test seat_number(player) == 5
-        state == 5 && @test seat_number(player) == 1
-        state == length(players) && break
-    end
-    @test state==length(players)
+    players = ntuple(i-> Player(Bot5050(), i), 5)
+    table = Table(;players = players)
+    TH.deal!(table, TH.blinds(table))
+    iter_players = collect(TH.circle(table, SmallBlind(), length(players)))
+    sn = seat_number.(iter_players)
+    @test sn == [2, 3, 4, 5, 1]
 
     # dealer_id = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(;players = players, dealer_id = 2)
     TH.deal!(table, TH.blinds(table))
-    state = 0
-    for player in TH.circle(table, SmallBlind())
-        state+=1
-        state == 1 && @test seat_number(player) == 3
-        state == 2 && @test seat_number(player) == 4
-        state == 3 && @test seat_number(player) == 5
-        state == 4 && @test seat_number(player) == 1
-        state == 5 && @test seat_number(player) == 2
-        state == length(players) && break
-    end
-    @test state==length(players)
+    iter_players = collect(TH.circle(table, SmallBlind(), length(players)))
+    sn = seat_number.(iter_players)
+    @test sn == [3, 4, 5, 1, 2]
 end
 
 @testset "Table: BigBlind iterator" begin
-
-    @test TH.default_dealer_id() == 1
-
-    players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players, dealer_id = TH.default_dealer_id())
-    TH.deal!(table, TH.blinds(table))
-
     # dealer_id = 1
-    state = 0
-    for player in TH.circle(table, BigBlind())
-        state+=1
-        state == 1 && @test seat_number(player) == 3
-        state == 2 && @test seat_number(player) == 4
-        state == 3 && @test seat_number(player) == 5
-        state == 4 && @test seat_number(player) == 1
-        state == 5 && @test seat_number(player) == 2
-        state == length(players) && break
-    end
-    @test state==length(players)
+    players = ntuple(i-> Player(Bot5050(), i), 5)
+    table = Table(;players = players)
+    TH.deal!(table, TH.blinds(table))
+    iter_players = collect(TH.circle(table, BigBlind(), length(players)))
+    sn = seat_number.(iter_players)
+    @test sn == [3, 4, 5, 1, 2]
 
     # dealer_id = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(;players = players, dealer_id = 2)
     TH.deal!(table, TH.blinds(table))
-    state = 0
-    for player in TH.circle(table, BigBlind())
-        state+=1
-        state == 1 && @test seat_number(player) == 4
-        state == 2 && @test seat_number(player) == 5
-        state == 3 && @test seat_number(player) == 1
-        state == 4 && @test seat_number(player) == 2
-        state == 5 && @test seat_number(player) == 3
-        state == length(players) && break
-    end
-    @test state==length(players)
+    iter_players = collect(TH.circle(table, BigBlind(), length(players)))
+    sn = seat_number.(iter_players)
+    @test sn == [4, 5, 1, 2, 3]
 end
 
 @testset "Table: FirstToAct iterator" begin
-
-    @test TH.default_dealer_id() == 1
-
-    players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players, dealer_id = TH.default_dealer_id())
-    TH.deal!(table, TH.blinds(table))
-
     # dealer_id = 1
-    state = 0
-    for player in TH.circle(table, FirstToAct())
-        state+=1
-        state == 1 && @test seat_number(player) == 4
-        state == 2 && @test seat_number(player) == 5
-        state == 3 && @test seat_number(player) == 1
-        state == 4 && @test seat_number(player) == 2
-        state == 5 && @test seat_number(player) == 3
-        state == length(players) && break
-    end
-    @test state==length(players)
+    players = ntuple(i-> Player(Bot5050(), i), 5)
+    table = Table(;players = players)
+    TH.deal!(table, TH.blinds(table))
+    iter_players = collect(TH.circle(table, FirstToAct(), length(players)))
+    sn = seat_number.(iter_players)
+    @test sn == [4, 5, 1, 2, 3]
 
     # dealer_id = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(;players = players, dealer_id = 2)
     TH.deal!(table, TH.blinds(table))
-    state = 0
-    for player in TH.circle(table, FirstToAct())
-        state+=1
-        state == 1 && @test seat_number(player) == 5
-        state == 2 && @test seat_number(player) == 1
-        state == 3 && @test seat_number(player) == 2
-        state == 4 && @test seat_number(player) == 3
-        state == 5 && @test seat_number(player) == 4
-        state == length(players) && break
-    end
-    @test state==length(players)
+    iter_players = collect(TH.circle(table, FirstToAct(), length(players)))
+    sn = seat_number.(iter_players)
+    @test sn == [5, 1, 2, 3, 4]
 end
 
 @testset "Table: iterate from player" begin
-
+    # dealer_id = 1
     @test TH.default_dealer_id() == 1
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players, dealer_id = TH.default_dealer_id())
+    table = Table(;players = players)
     TH.deal!(table, TH.blinds(table))
-    # dealer_id = 1
-    state = 0
-    for player in TH.circle(table, players[1])
-        state+=1
-        @test seat_number(player) == state
-        state == length(players) && break
-    end
-    @test state==length(players)
+    iter_players = collect(TH.circle(table, players[1], length(players)))
+    sn = seat_number.(iter_players)
+    @test sn == [1, 2, 3, 4, 5]
 
+    # dealer_id = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(;players = players, dealer_id = 2)
     TH.deal!(table, TH.blinds(table))
-    # dealer_id = 2
-    state = 0
-    for player in TH.circle(table, players[1])
-        state+=1
-        @test seat_number(player) == state
-        state == length(players) && break
-    end
-    @test state==length(players)
+    iter_players = collect(TH.circle(table, players[1], length(players)))
+    sn = seat_number.(iter_players)
+    @test sn == [1, 2, 3, 4, 5]
 
-    players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players, dealer_id = TH.default_dealer_id())
-    TH.deal!(table, TH.blinds(table))
     # dealer_id = 1
-    state = 0
-    for player in TH.circle(table, players[2])
-        state+=1
-        state == 1 && @test seat_number(player) == 2
-        state == 2 && @test seat_number(player) == 3
-        state == 3 && @test seat_number(player) == 4
-        state == 4 && @test seat_number(player) == 5
-        state == 5 && @test seat_number(player) == 1
-        state == length(players) && break
-    end
-    @test state==length(players)
+    players = ntuple(i-> Player(Bot5050(), i), 5)
+    table = Table(;players = players)
+    TH.deal!(table, TH.blinds(table))
+    iter_players = collect(TH.circle(table, players[2], length(players)))
+    sn = seat_number.(iter_players)
+    @test sn == [2, 3, 4, 5, 1]
 
+    # dealer_id = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(;players = players, dealer_id = 2)
     TH.deal!(table, TH.blinds(table))
-    # dealer_id = 2
-    state = 0
-    for player in TH.circle(table, players[2])
-        state+=1
-        state == 1 && @test seat_number(player) == 2
-        state == 2 && @test seat_number(player) == 3
-        state == 3 && @test seat_number(player) == 4
-        state == 4 && @test seat_number(player) == 5
-        state == 5 && @test seat_number(player) == 1
-        state == length(players) && break
-    end
-    @test state==length(players)
+    iter_players = collect(TH.circle(table, players[2], length(players)))
+    sn = seat_number.(iter_players)
+    @test sn == [2, 3, 4, 5, 1]
 end


### PR DESCRIPTION
 - Button -> Dealer
 - `circle_table` -> `circle_index`, which only takes the length and state for indexing `players`
 - Remove `position`
 - add `n_iter` to iterators, so that we can collect the results and simplify the tests