### PR TITLE
Add tournament play fuzz test back in

### DIFF
--- a/src/game.jl
+++ b/src/game.jl
@@ -115,9 +115,11 @@ function act_generic!(game::Game, state::AbstractGameState)
 
     any_actions_required(game) || return
     for (i, player) in enumerate(circle(table, FirstToAct()))
+        @debug "Checking to see if it's $(name(player))'s turn to act"
+        @debug "     not_playing(player) = $(not_playing(player))"
+        @debug "     all_in(player) = $(all_in(player))"
         not_playing(player) && continue # skip players not playing
         set_preflop_blind_raise!(table, player, state, i)
-        @debug "Checking to see if it's $(name(player))'s turn to act"
         if end_of_actions(table, player)
             break
         end

--- a/src/transactions.jl
+++ b/src/transactions.jl
@@ -58,11 +58,12 @@ amount(tm::TransactionManager) = amount(tm.side_pots[tm.pot_id[1]])
 cap(tm::TransactionManager) = cap(tm.side_pots[tm.pot_id[1]])
 
 function last_action_of_round(table, player, call)
-    @debug "Determining last_action_of_round"
-    @debug "    action_required.(players_at_table(table)) = $(action_required.(players_at_table(table)))"
-    @debug "    all_oppononents_all_in(table, player) = $(all_oppononents_all_in(table, player))"
-    @debug "    call = $call"
-    return all_oppononents_all_in(table, player) || (count(action_required.(players_at_table(table))) == 0 && call)
+    laor = all_oppononents_all_in(table, player) || (count(action_required.(players_at_table(table))) == 0 && call)
+    @debug "last_action_of_round = $laor"
+    # @debug "    action_required.(players_at_table(table)) = $(action_required.(players_at_table(table)))"
+    # @debug "    all_oppononents_all_in(table, player) = $(all_oppononents_all_in(table, player))"
+    # @debug "    call = $call"
+    return laor
 end
 
 """

--- a/test/fuzz_play.jl
+++ b/test/fuzz_play.jl
@@ -20,9 +20,8 @@ end
     end
 end
 
-# Too many things are broken to support this.
-# @testset "Game: tournament! (10 Bot5050's)" begin
-#     for n in 1:n_fuzz_10_players
-#         tournament!(Game(ntuple(i->Player(Bot5050(), i; bank_roll = 6), 10)))
-#     end
-# end
+@testset "Game: tournament! (10 Bot5050's)" begin
+    for n in 1:n_fuzz_10_players
+        tournament!(Game(ntuple(i->Player(Bot5050(), i; bank_roll = 6), 10)))
+    end
+end


### PR DESCRIPTION
I was trying to reproduce #59, but I'm not seeing it anymore. It may have been eliminated from all of the fixups with `folder` -> `active`/`still_playing` changes.