### PR TITLE
Ensure raises are called, fix edge cases with player options

### DIFF
--- a/src/player_actions.jl
+++ b/src/player_actions.jl
@@ -246,10 +246,12 @@ function raise_to_valid_raise_amount!(table::Table, player::Player, amt::Real)
     for opponent in players
         seat_number(opponent) == seat_number(player) && continue
         not_playing(opponent) && continue
-        all_in(opponent) && continue
-        opponent.action_required = true
-        opponent.checked = false # to avoid exiting on all_all_in_or_checked(table). TODO: there's got to be a cleaner way
+        if !all_in(opponent)
+            opponent.action_required = true
+        end
         opponent.last_to_raise = false
+        # TODO: there's got to be a cleaner way
+        opponent.checked = false # to avoid exiting on all_all_in_or_checked(table).
     end
     if bank_roll(player) ≈ 0
         if isempty(pbpai)

--- a/test/fuzz_play.jl
+++ b/test/fuzz_play.jl
@@ -20,6 +20,12 @@ end
     end
 end
 
+@testset "Game: tournament! (3 Bot5050's)" begin
+    for n in 1:n_fuzz_3_players
+        tournament!(Game(ntuple(i->Player(Bot5050(), i; bank_roll = 6), 3)))
+    end
+end
+
 @testset "Game: tournament! (10 Bot5050's)" begin
     for n in 1:n_fuzz_10_players
         tournament!(Game(ntuple(i->Player(Bot5050(), i; bank_roll = 6), 10)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ submodules = [
 local_run = isempty(get(ENV, "CI", ""))
 n_fuzz = local_run ? 10 : 100
 n_fuzz_10_players = local_run ? 1 : 10
+n_fuzz_3_players = local_run ? 10 : 20
 
 tests_to_debug = ["play", "fuzz_play"]
 # tests_to_debug = submodules


### PR DESCRIPTION
This PR
 - Adds an assertion to ensure raises are called (via `all_raises_were_called`)
 - Fixes an edge cases where players are incorrectly given options when they shouldn't have any. For example, consider a heads-up game when the small blind player calls small blind (and is then all-in), the big blind has paid the blind, and has no action to make. In this case, the big blind was incorrectly given the option to check/raise/fold, which lead to downstream errors.
 - Adding `!action_required(br_leader)` to `cond3` helped fix an edge case (maybe helped with the same one above?)