### PR TITLE
Fix extra betting round

### DIFF
--- a/src/game.jl
+++ b/src/game.jl
@@ -179,6 +179,7 @@ function act_generic!(game::Game, state::AbstractGameState)
         table.winners.declared && break
         end_preflop_actions(table, player, state) && break
     end
+    @info "Betting is finished"
     @assert all_raises_were_called(table)
 end
 

--- a/src/game.jl
+++ b/src/game.jl
@@ -146,6 +146,14 @@ function all_raises_were_called(table::Table)
     return all(map(cond->any(cond), conds))
 end
 
+end_preflop_actions(table, player, ::AbstractGameState) = false
+function end_preflop_actions(table::Table, player::Player, ::PreFlop)
+    cond1 = is_big_blind(table, player)
+    cond2 = checked(player)
+    cond3 = still_playing(player)
+    return all((cond1, cond2, cond3))
+end
+
 function act_generic!(game::Game, state::AbstractGameState)
     table = game.table
     table.winners.declared && return
@@ -169,6 +177,7 @@ function act_generic!(game::Game, state::AbstractGameState)
         @debug "$(name(player))'s turn to act"
         player_option!(game, player)
         table.winners.declared && break
+        end_preflop_actions(table, player, state) && break
     end
     @assert all_raises_were_called(table)
 end


### PR DESCRIPTION
One thing I just noticed is that sometimes players are given an extra pre-flop action:
```
Extra round of pre-flop betting...
[ Info: ------ Playing game!
[ Info: Initial bank roll summary: (260.0, 0.0, 37.0, 0.0, 203.0)
[ Info: Buttons (dealer, small, big, 1ˢᵗToAct): (1, 3, 5, 1)
[ Info: Bot5050[3] paid the small blind and dealt cards: ??
[ Info: Bot5050[5] paid the  big  blind and dealt cards: ??
[ Info: Human[1] dealt (free) cards:                   (Q♢, 2♢)
[ Info: Table cards dealt (face-down).
[ Info: Pre-flop!
Human[1]'s turn to act:
 > Call $2.0 (blind)
   Raise [$4.0, $203.0]
   Fold
[ Info: Human[1] called 2.0 (blind).
[ Info: Bot5050[3] called 1.0 (blind).
[ Info: Bot5050[5] checked!
Human[1]'s turn to act:
 > Check
   Raise [$4.0, $203.0]
   Fold
[ Info: Human[1] checked!
[ Info: Bot5050[3] raised to 20.0.
[ Info: Bot5050[5] called 18.0.
Human[1]'s turn to act:
   Call $18.0
   Raise [$40.0, $203.0]
 > Fold
```

`[ Info: Bot5050[5] checked!` should be the last action of the round. This PR should fix this edge case, which only happens pre-flop. And adds some `@info` prints informing that the betting has ended for a given round.