### PR TITLE
End correctly on pre-flop betting when bb checks, add tests

### DIFF
--- a/src/game.jl
+++ b/src/game.jl
@@ -146,6 +146,14 @@ function all_raises_were_called(table::Table)
     return all(map(cond->any(cond), conds))
 end
 
+end_preflop_actions(table, player, ::AbstractGameState) = false
+function end_preflop_actions(table::Table, player::Player, ::PreFlop)
+    cond1 = is_big_blind(table, player)
+    cond2 = checked(player)
+    cond3 = still_playing(player)
+    return all((cond1, cond2, cond3))
+end
+
 function act_generic!(game::Game, state::AbstractGameState)
     table = game.table
     table.winners.declared && return
@@ -169,7 +177,9 @@ function act_generic!(game::Game, state::AbstractGameState)
         @debug "$(name(player))'s turn to act"
         player_option!(game, player)
         table.winners.declared && break
+        end_preflop_actions(table, player, state) && break
     end
+    @info "Betting is finished."
     @assert all_raises_were_called(table)
 end
 

--- a/test/play.jl
+++ b/test/play.jl
@@ -104,12 +104,12 @@ n_call_actions = [0]
         Player(BotNActions(), 3),
         Player(BotNActions(), 4; bank_roll = 0),
         Player(BotNActions(), 5),
-    );dealer_id = 1))
+    ); dealer_id = 1))
 
     @test n_call_actions[1] == 2 # dealer + small blind
     # 1 check pre-flop (big blind)
     # 3 checks (flop)
     # 3 checks (turn)
     # 3 checks (river)
-    @test_broken n_check_actions[1] == 10 # TODO: Fix me!
+    @test n_check_actions[1] == 10
 end

--- a/test/play.jl
+++ b/test/play.jl
@@ -68,3 +68,48 @@ end
     play!(game)
 end
 
+n_check_actions = [0]
+n_call_actions = [0]
+@testset "N-actions (3 players)" begin
+    play!(Game(ntuple(i->Player(BotNActions(), i), 3)))
+    @test n_call_actions[1] == 2 # dealer + small blind
+    # 1 check pre-flop (big blind)
+    # 3 checks (flop)
+    # 3 checks (turn)
+    # 3 checks (river)
+    @test n_check_actions[1] == 10
+end
+
+n_check_actions = [0]
+n_call_actions = [0]
+@testset "N-actions (4 players)" begin
+    play!(Game(ntuple(i->Player(BotNActions(), i), 4)))
+    @test n_call_actions[1] == 3 # dealer + small blind + 1 other
+    # 1 check pre-flop (big blind)
+    # 4 checks (flop)
+    # 4 checks (turn)
+    # 4 checks (river)
+    @test n_check_actions[1] == 13
+end
+
+n_check_actions = [0]
+n_call_actions = [0]
+@testset "N-actions (custom)" begin
+    # Inspired by:
+    # [ Info: Initial bank roll summary: (260.0, 0.0, 37.0, 0.0, 203.0)
+    # [ Info: Buttons (dealer, small, big, 1ˢᵗToAct): (1, 3, 5, 1)
+    play!(Game((
+        Player(BotNActions(), 1),
+        Player(BotNActions(), 2; bank_roll = 0),
+        Player(BotNActions(), 3),
+        Player(BotNActions(), 4; bank_roll = 0),
+        Player(BotNActions(), 5),
+    );dealer_id = 1))
+
+    @test n_call_actions[1] == 2 # dealer + small blind
+    # 1 check pre-flop (big blind)
+    # 3 checks (flop)
+    # 3 checks (turn)
+    # 3 checks (river)
+    @test_broken n_check_actions[1] == 10 # TODO: Fix me!
+end

--- a/test/tester_bots.jl
+++ b/test/tester_bots.jl
@@ -96,3 +96,16 @@ TH.player_option!(game::Game, player::Player{BotRaiseOnCallFold}, ::AGS, ::CallF
 struct BotLimpAllIn <: AbstractAI end
 
 TH.player_option!(game::Game, player::Player{BotLimpAllIn}, ::AGS, ::PlayerOptions) = call!(game, player)
+
+##### BotNActions
+struct BotNActions <: AbstractAI end
+
+function TH.player_option!(game::Game, player::Player{BotNActions}, ::AGS, ::CheckRaiseFold)
+    check!(game, player)
+    n_check_actions[1]+=1
+end
+
+function TH.player_option!(game::Game, player::Player{BotNActions}, ::AGS, ::CallRaiseFold)
+    call!(game, player)
+    n_call_actions[1]+=1
+end


### PR DESCRIPTION
Supersedes #86: End correctly on pre-flop betting when bb checks and adds a regression test.