### PR TITLE
Fix tournament bug with action required

### DIFF
--- a/src/game.jl
+++ b/src/game.jl
@@ -178,6 +178,9 @@ function act_generic!(game::Game, state::AbstractGameState)
         player_option!(game, player)
         table.winners.declared && break
         end_preflop_actions(table, player, state) && break
+        if i > n_max_actions(table)
+            error("Too many actions have occured, please open an issue.")
+        end
     end
     @info "Betting is finished."
     @assert all_raises_were_called(table)
@@ -259,9 +262,11 @@ function set_active_status!(table::Table)
         if zero_bank_roll(player) # TODO: should we remove these players from the table?
             player.active = false
             player.folded = true
+            player.action_required = false
         else
             player.active = true
             player.folded = false
+            player.action_required = true
         end
     end
 end
@@ -281,7 +286,6 @@ function reset_game!(game::Game)
     for player in players
         player.cards = nothing
         player.pot_investment = 0
-        player.action_required = true
         player.all_in = false
         player.round_bank_roll = bank_roll(player)
         player.checked = false

--- a/src/player_types.jl
+++ b/src/player_types.jl
@@ -85,3 +85,4 @@ inactive(player::Player) = !active(player)
 round_bank_roll(player::Player) = player.round_bank_roll
 pot_investment(player::Player) = player.pot_investment
 round_contribution(player::Player) = player.round_contribution
+life_form(player::Player) = player.life_form

--- a/test/play.jl
+++ b/test/play.jl
@@ -94,7 +94,7 @@ end
 
 n_check_actions = [0]
 n_call_actions = [0]
-@testset "N-actions (custom)" begin
+@testset "N-actions (custom 1)" begin
     # Inspired by:
     # [ Info: Initial bank roll summary: (260.0, 0.0, 37.0, 0.0, 203.0)
     # [ Info: Buttons (dealer, small, big, 1ˢᵗToAct): (1, 3, 5, 1)
@@ -112,4 +112,26 @@ n_call_actions = [0]
     # 3 checks (turn)
     # 3 checks (river)
     @test n_check_actions[1] == 10
+end
+
+n_check_actions = [0]
+n_call_actions = [0]
+@testset "N-actions (custom 2)" begin
+    # Inspired by:
+    # [ Info: Initial bank roll summary: (195.0, 0.0, 256.0, 4.0, 45.0)
+    # [ Info: Buttons (dealer, small, big, 1ˢᵗToAct): (5, 1, 3, 4)
+    play!(Game((
+        Player(BotNActions(), 1; bank_roll = 195.0),
+        Player(BotCheckCall(), 2; bank_roll = 0),
+        Player(BotPreFlopRaise(7.0), 3; bank_roll = 256.0),
+        Player(BotCheckCall(), 4; bank_roll = 4.0),
+        Player(BotCheckFold(), 5; bank_roll = 45.0),
+    ); dealer_id = 1))
+
+    @test n_call_actions[1] == 2 # dealer + small blind
+    # 1 check pre-flop (big blind)
+    # 3 checks (flop)
+    # 3 checks (turn)
+    # 3 checks (river)
+    @test n_check_actions[1] == 3
 end

--- a/test/tester_bots.jl
+++ b/test/tester_bots.jl
@@ -109,3 +109,15 @@ function TH.player_option!(game::Game, player::Player{BotNActions}, ::AGS, ::Cal
     call!(game, player)
     n_call_actions[1]+=1
 end
+
+##### BotPreFlopRaise
+struct BotPreFlopRaise{FT} <: AbstractAI
+    amt::FT
+end
+# Call blind / check pre-flop, raise on flop
+
+TH.player_option!(game::Game, player::Player{<:BotPreFlopRaise}, ::AGS, ::CheckRaiseFold) = check!(game, player)
+TH.player_option!(game::Game, player::Player{<:BotPreFlopRaise}, ::AGS, ::CallRaiseFold) = raise_to!(game, player, TH.life_form(player).amt)
+TH.player_option!(game::Game, player::Player{<:BotPreFlopRaise}, ::AGS, ::CallAllInFold) = call!(game, player)
+TH.player_option!(game::Game, player::Player{<:BotPreFlopRaise}, ::AGS, ::CallFold) = call!(game, player)
+TH.player_option!(game::Game, player::Player{<:BotPreFlopRaise}, ::PreFlop, ::CheckRaiseFold) = raise_to!(game, player, TH.life_form(player).amt)


### PR DESCRIPTION
This PR:
 - Adds a test, which caught a case where the last action was incorrectly missed, and players 1 and 3 had options to infinitely check.
 - Adds `n_max_actions(table)` to protect against infinite loops around the table
 - Sets the `action_required` in `set_active_status!`, since it must be set to false for inactive players, this fixed the infinite loop.
