### PR TITLE
Exclude game state from `player_option!`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ An experimental package for simulating no-limit Texas Holdem Poker. We're not re
 
 # Playing
 
-Games can be played with:
+A single game can be played with `play!` and tournament-style game with `tournament!`:
 
 ```julia
 using TexasHoldem
-play!(configure_game())
+play!(configure_game()) # play 1 game
+tournament!(configure_game()) # play until 1 player remains
 ```
 
 # Creating your own bot
@@ -49,7 +50,7 @@ TH = TexasHoldem
 
 struct MyBot <: AbstractAI end
 
-function TH.player_option!(game::Game, player::Player{MyBot}, ::AbstractGameState, ::CheckRaiseFold)
+function TH.player_option!(game::Game, player::Player{MyBot}, ::CheckRaiseFold)
     # options are:
     #    check!(game, player)
     #    raise!(game, player, amt::Float64)
@@ -63,7 +64,7 @@ function TH.player_option!(game::Game, player::Player{MyBot}, ::AbstractGameStat
         raise_to!(game, player, amt)
     end
 end
-function TH.player_option!(game::Game, player::Player{MyBot}, ::AbstractGameState, ::CallRaiseFold)
+function TH.player_option!(game::Game, player::Player{MyBot}, ::CallRaiseFold)
     # options are:
     #    call!(game, player)
     #    raise!(game, player, amt::Float64)
@@ -81,7 +82,7 @@ function TH.player_option!(game::Game, player::Player{MyBot}, ::AbstractGameStat
         fold!(game, player)
     end
 end
-function TH.player_option!(game::Game, player::Player{MyBot}, ::AbstractGameState, ::CallAllInFold)
+function TH.player_option!(game::Game, player::Player{MyBot}, ::CallAllInFold)
     # options are:
     #    call!(game, player)
     #    raise_all_in!(game, player)
@@ -96,7 +97,7 @@ function TH.player_option!(game::Game, player::Player{MyBot}, ::AbstractGameStat
         fold!(game, player)
     end
 end
-function TH.player_option!(game::Game, player::Player{MyBot}, ::AbstractGameState, ::CallFold)
+function TH.player_option!(game::Game, player::Player{MyBot}, ::CallFold)
     # options are:
     #    call!(game, player)
     #    fold!(game, player)
@@ -108,5 +109,5 @@ function TH.player_option!(game::Game, player::Player{MyBot}, ::AbstractGameStat
 end
 
 # Heads-up against the MyBot!
-play!(Game((Player(Human(), 1), Player(MyBot(), 2))))
+tournament!(Game((Player(Human(), 1), Player(MyBot(), 2))))
 ```

--- a/perf.jl
+++ b/perf.jl
@@ -6,10 +6,10 @@ using Logging
 
 struct BotCheckCall <: AbstractAI end
 
-TH.player_option!(game::Game, player::Player{BotCheckCall}, ::AbstractGameState, ::CheckRaiseFold) = check!(game, player)
-TH.player_option!(game::Game, player::Player{BotCheckCall}, ::AbstractGameState, ::CallRaiseFold) = call!(game, player)
-TH.player_option!(game::Game, player::Player{BotCheckCall}, ::AbstractGameState, ::CallAllInFold) = call!(game, player)
-TH.player_option!(game::Game, player::Player{BotCheckCall}, ::AbstractGameState, ::CallFold) = call!(game, player)
+TH.player_option!(game::Game, player::Player{BotCheckCall}, ::CheckRaiseFold) = check!(game, player)
+TH.player_option!(game::Game, player::Player{BotCheckCall}, ::CallRaiseFold) = call!(game, player)
+TH.player_option!(game::Game, player::Player{BotCheckCall}, ::CallAllInFold) = call!(game, player)
+TH.player_option!(game::Game, player::Player{BotCheckCall}, ::CallFold) = call!(game, player)
 
 players() = ntuple(i->(Player(BotCheckCall(), i)), 4)
 

--- a/profile.jl
+++ b/profile.jl
@@ -6,10 +6,10 @@ using Logging
 
 struct BotCheckCall <: AbstractAI end
 
-TH.player_option!(game::Game, player::Player{BotCheckCall}, ::AbstractGameState, ::CheckRaiseFold) = check!(game, player)
-TH.player_option!(game::Game, player::Player{BotCheckCall}, ::AbstractGameState, ::CallRaiseFold) = call!(game, player)
-TH.player_option!(game::Game, player::Player{BotCheckCall}, ::AbstractGameState, ::CallAllInFold) = call!(game, player)
-TH.player_option!(game::Game, player::Player{BotCheckCall}, ::AbstractGameState, ::CallFold) = call!(game, player)
+TH.player_option!(game::Game, player::Player{BotCheckCall}, ::CheckRaiseFold) = check!(game, player)
+TH.player_option!(game::Game, player::Player{BotCheckCall}, ::CallRaiseFold) = call!(game, player)
+TH.player_option!(game::Game, player::Player{BotCheckCall}, ::CallAllInFold) = call!(game, player)
+TH.player_option!(game::Game, player::Player{BotCheckCall}, ::CallFold) = call!(game, player)
 
 players() = ntuple(i->(Player(BotCheckCall(), i)), 4)
 

--- a/src/config_game.jl
+++ b/src/config_game.jl
@@ -151,10 +151,3 @@ function configure_game()
         println("Menu canceled.")
     end
 end
-
-export configure_play_game
-function configure_play_game()
-    # game = configure_game()
-    game = configure_basic_heads_up_game()
-    play!(game)
-end

--- a/test/human_player_option.jl
+++ b/test/human_player_option.jl
@@ -24,20 +24,20 @@ end
     players = (Player(Human(), 1), Player(Bot5050(), 2))
     game = Game(players)
     simulate_keystrokes(:down, :down, :enter, 'd')
-    TH.player_option!(game, players[1], PreFlop(), CheckRaiseFold())
+    TH.player_option!(game, players[1], CheckRaiseFold())
     simulate_keystrokes(:down, :down, :enter, 'd')
-    TH.player_option!(game, players[1], PreFlop(), CallRaiseFold())
+    TH.player_option!(game, players[1], CallRaiseFold())
     simulate_keystrokes(:down, :down, :enter, 'd')
-    TH.player_option!(game, players[1], PreFlop(), CallAllInFold())
+    TH.player_option!(game, players[1], CallAllInFold())
     simulate_keystrokes(:down, :enter, 'd')
-    TH.player_option!(game, players[1], PreFlop(), CallFold())
+    TH.player_option!(game, players[1], CallFold())
 end
 
 @testset "Test check" begin
     players = (Player(Human(), 1), Player(Bot5050(), 2))
     game = Game(players)
     simulate_keystrokes(:enter, 'd')
-    TH.player_option!(game, players[1], PreFlop(), CheckRaiseFold())
+    TH.player_option!(game, players[1], CheckRaiseFold())
 end
 
 @testset "Test call" begin
@@ -46,21 +46,21 @@ end
     game = Game(players)
     game.table.current_raise_amt = 10.0
     simulate_keystrokes(:enter, 'd', 10.0)
-    TH.player_option!(game, players[1], PreFlop(), CallRaiseFold())
+    TH.player_option!(game, players[1], CallRaiseFold())
     @test last(TH.action_history(players[1])) == Call{Float64}(10.0)
 
     players = (Player(Human(), 1), Player(Bot5050(), 2))
     game = Game(players)
     game.table.current_raise_amt = 10.0
     simulate_keystrokes(:enter, 'd', 10.0)
-    TH.player_option!(game, players[1], PreFlop(), CallAllInFold())
+    TH.player_option!(game, players[1], CallAllInFold())
     @test last(TH.action_history(players[1])) == Call{Float64}(10.0)
 
     players = (Player(Human(), 1), Player(Bot5050(), 2))
     game = Game(players)
     game.table.current_raise_amt = 10.0
     simulate_keystrokes(:enter, 'd', 10.0)
-    TH.player_option!(game, players[1], PreFlop(), CallFold())
+    TH.player_option!(game, players[1], CallFold())
     @test last(TH.action_history(players[1])) == Call{Float64}(10.0)
 end
 
@@ -70,7 +70,7 @@ end
     game = Game(players)
     game.table.current_raise_amt = 10.0
     simulate_keystrokes(:down, :enter, 'd')
-    TH.player_option!(game, players[1], PreFlop(), CallAllInFold())
+    TH.player_option!(game, players[1], CallAllInFold())
     @test last(TH.action_history(players[1])) == Raise{Float64}(200.0)
 end
 
@@ -109,7 +109,7 @@ TH.use_input_io() = true
     simulate_keystrokes(:down, :enter) # select Raise
     TRT.automated_test(file, [10]) do emuterm
         @testset "Human player options: CheckRaiseFold" begin
-            TH.player_option!(game, players[1], PreFlop(), CheckRaiseFold(), emuterm)
+            TH.player_option!(game, players[1], CheckRaiseFold(), emuterm)
         end
     end
 
@@ -121,7 +121,7 @@ TH.use_input_io() = true
     simulate_keystrokes(:down, :enter) # select Raise
     TRT.automated_test(file, [20]) do emuterm
         @testset "Human player options: CallRaiseFold" begin
-            TH.player_option!(game, players[1], PreFlop(), CallRaiseFold(), emuterm)
+            TH.player_option!(game, players[1], CallRaiseFold(), emuterm)
         end
     end
 end


### PR DESCRIPTION
This PR removes game state from the argument list to `player_option!`. Most of the time this argument isn't needed, but we've provided a fallback so that it's called if nothing else is caught.