### PR TITLE
Check for and declare winners after every game

### DIFF
--- a/src/game.jl
+++ b/src/game.jl
@@ -251,6 +251,7 @@ function play!(game::Game)
     @assert sum(amount.(table.transactions.side_pots)) ≈ 0
 
     @info "Final bank roll summary: $(bank_roll.(players))"
+    check_for_and_declare_winners!(game.table) # in case nobody folds
 
     @info "------ Finished game!"
     return winners

--- a/src/player_actions.jl
+++ b/src/player_actions.jl
@@ -24,7 +24,7 @@ function fold!(game::Game, player::Player)
     push!(player.action_history, Fold())
     player.action_required = false
     player.folded = true
-    check_for_winner!(game.table)
+    check_for_and_declare_winners!(game.table)
     @info "$(name(player)) folded!"
 end
 

--- a/src/table.jl
+++ b/src/table.jl
@@ -335,7 +335,7 @@ function set_state!(table::Table, state::AbstractGameState)
     table.state = state
 end
 
-function check_for_winner!(table::Table)
+function check_for_and_declare_winners!(table::Table)
     players = players_at_table(table)
     n_players = length(players)
     table.winners.declared = count(not_playing.(players)) == n_players-1


### PR DESCRIPTION
Sometimes `winners` is not populated (when nobody folds).