### PR TITLE
Fix returned winning players

### DIFF
--- a/src/game.jl
+++ b/src/game.jl
@@ -239,7 +239,8 @@ function play!(game::Game)
     winners.declared || act!(game, Turn())      # Deal turn , then bet/check/raise
     winners.declared || act!(game, River())     # Deal river, then bet/check/raise
 
-    distribute_winnings!(players, table.transactions, cards(table))
+    winners.players = distribute_winnings!(players, table.transactions, cards(table))
+    winners.declared = true
 
     @debug "amount.(table.transactions.side_pots) = $(amount.(table.transactions.side_pots))"
     @debug "initial_∑brs = $(initial_∑brs)"
@@ -251,7 +252,7 @@ function play!(game::Game)
     @assert sum(amount.(table.transactions.side_pots)) ≈ 0
 
     @info "Final bank roll summary: $(bank_roll.(players))"
-    check_for_and_declare_winners!(game.table) # in case nobody folds
+    @assert winners.declared
 
     @info "------ Finished game!"
     return winners

--- a/src/player_actions.jl
+++ b/src/player_actions.jl
@@ -24,7 +24,7 @@ function fold!(game::Game, player::Player)
     push!(player.action_history, Fold())
     player.action_required = false
     player.folded = true
-    check_for_and_declare_winners!(game.table)
+    check_for_and_declare_winner!(game.table)
     @info "$(name(player)) folded!"
 end
 

--- a/src/table.jl
+++ b/src/table.jl
@@ -335,7 +335,9 @@ function set_state!(table::Table, state::AbstractGameState)
     table.state = state
 end
 
-function check_for_and_declare_winners!(table::Table)
+# Check for winner, in case when only a single player remains
+# playing
+function check_for_and_declare_winner!(table::Table)
     players = players_at_table(table)
     n_players = length(players)
     table.winners.declared = count(not_playing.(players)) == n_players-1

--- a/src/transactions.jl
+++ b/src/transactions.jl
@@ -202,6 +202,7 @@ function distribute_winnings!(players, tm::TransactionManager, table_cards)
         zeros(length(tm.side_pots))
     end
     winning_hands = Vector{Symbol}(undef, length(players))
+    all_winning_players = Player[]
 
     for i in 1:length(tm.side_pots)
         sidepot_winnings(tm, length(players)) ≈ 0 && continue # no money left to distribute
@@ -239,6 +240,7 @@ function distribute_winnings!(players, tm::TransactionManager, table_cards)
             win_seat = seat_number(tm.sorted_players[winner_id])
             winning_player = players[win_seat]
             not_playing(winning_player) && continue
+            push!(all_winning_players, winning_player)
             amt = sidepot_winnings(tm, i) / n_winners
             side_pot_winnings[win_seat][i] = amt
             winning_hands[win_seat] = hand_type(hand_evals_sorted[winner_id].fhe)
@@ -271,4 +273,5 @@ function distribute_winnings!(players, tm::TransactionManager, table_cards)
     end
 
     @debug "Distributed winnings..."
+    return Tuple(all_winning_players)
 end


### PR DESCRIPTION
#100 didn't quite do what was needed. Since `check_for_and_declare_winners!` only works when one player is still playing. This misses the cases when there are multiple winners, or when nobody folds. This PR ensures that the winners (who money is distributed to) are returned from `play!`.