### PR TITLE
Add inferable logger path

### DIFF
--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -5,7 +5,7 @@ import TexasHoldem
 const TH = TexasHoldem
 using TexasHoldem
 using BenchmarkTools
-using Logging
+import Logging
 
 struct BotCheckCall <: AbstractAI end
 

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -5,7 +5,7 @@ import TexasHoldem
 const TH = TexasHoldem
 using TexasHoldem
 using BenchmarkTools
-using Logging
+import Logging
 
 struct BotCheckCall <: AbstractAI end
 
@@ -17,7 +17,7 @@ TH.player_option!(game::Game, player::Player{BotCheckCall}, ::CallFold) = call!(
 players() = ntuple(i->(Player(BotCheckCall(), i)), 4)
 
 function do_work!(games)
-    with_logger(NullLogger()) do
+    Logging.with_logger(Logging.NullLogger()) do
         for game in games
             play!(game)
         end

--- a/perf/jet.jl
+++ b/perf/jet.jl
@@ -5,7 +5,6 @@ import TexasHoldem
 const TH = TexasHoldem
 using TexasHoldem
 using BenchmarkTools
-using Logging
 
 struct BotCheckCall <: AbstractAI end
 
@@ -17,16 +16,15 @@ TH.player_option!(game::Game, player::Player{BotCheckCall}, ::CallFold) = call!(
 players() = ntuple(i->(Player(BotCheckCall(), i)), 4)
 
 function do_work!(game)
-    with_logger(NullLogger()) do
-        play!(game)
-    end
+    play!(game)
     return nothing
 end
 
 # Make sure it runs without errors
-game = Game(players())
+game = Game(players();logger=TH.ByPassLogger())
+println("------------ about to do work")
 do_work!(game)
 
 import JET
-game = Game(players())
+game = Game(players();logger=TH.ByPassLogger())
 JET.@test_opt do_work!(game)

--- a/src/TexasHoldem.jl
+++ b/src/TexasHoldem.jl
@@ -19,6 +19,8 @@ using Printf
 
 export AbstractGameState, PreFlop, Flop, Turn, River
 
+include("custom_logger.jl")
+
 abstract type AbstractGameState end
 struct PreFlop <: AbstractGameState end
 struct Flop <: AbstractGameState end

--- a/src/custom_logger.jl
+++ b/src/custom_logger.jl
@@ -1,0 +1,40 @@
+#=
+Custom logging was added so type-unstable logging
+functions in the Logging infrastructure is elided.
+=#
+import Logging
+
+struct StandardLogger end
+struct ByPassLogger end
+
+macro cdebug(logger, expr)
+    return quote
+        if !($(esc(logger)) isa ByPassLogger)
+            @debug $(esc(expr))
+        end
+    end
+end
+
+macro cwarn(logger, expr)
+    return quote
+        if !($(esc(logger)) isa ByPassLogger)
+            @warn $(esc(expr))
+        end
+    end
+end
+
+macro cerror(logger, expr)
+    return quote
+        if !($(esc(logger)) isa ByPassLogger)
+            @error $(esc(expr))
+        end
+    end
+end
+
+macro cinfo(logger, expr)
+    return quote
+        if !($(esc(logger)) isa ByPassLogger)
+            @info $(esc(expr))
+        end
+    end
+end

--- a/src/player_options.jl
+++ b/src/player_options.jl
@@ -32,6 +32,7 @@ validate_action(::Raise, ::CallAllInFold) = nothing
 validate_action(::Raise, ::CallFold) = error("Cannot Raise. Available options: CallFold")
 
 function player_option!(game::Game, player::Player)
+    logger = game.table.logger
     table = game.table
     call_amt = call_amount(table, player)
     if !(call_amt ≈ 0) # must call to stay in
@@ -51,7 +52,7 @@ function player_option!(game::Game, player::Player)
     else
         option = CheckRaiseFold()
     end
-    @debug "option = $option"
+    @cdebug logger "option = $option"
 
     n_actions = length(action_history(player))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Logging
+import Logging
 
 metafmt(level, _module, group, id, file, line) =
     Logging.default_metafmt(level, nothing, group, id, nothing, nothing)
@@ -27,12 +27,12 @@ for submodule in submodules
     t = 0
     local logger
     if any(submodule in tests_to_debug)
-        logger = ConsoleLogger(stderr,Logging.Info)
+        logger = Logging.ConsoleLogger(stderr,Logging.Info)
         # logger = ConsoleLogger(stderr,Logging.Debug;meta_formatter=metafmt)
     else
-        logger = NullLogger()
+        logger = Logging.NullLogger()
     end
-    with_logger(logger) do
+    Logging.with_logger(logger) do
         t = @elapsed include(submodule*".jl")
     end
     println("Completed tests for $submodule, $(round(Int, t)) seconds elapsed")

--- a/test/table.jl
+++ b/test/table.jl
@@ -1,6 +1,6 @@
 using Test
 using PlayingCards
-using Logging
+import Logging
 using TexasHoldem
 using TexasHoldem: seat_number
 TH = TexasHoldem


### PR DESCRIPTION
Add and pass custom logger. This helps reduce the noise when running JET. Ironically, it results in more JET failures, but this is likely due to JET being able to analyze past the logging failures.