### PR TITLE
Define and use Players

### DIFF
--- a/src/game.jl
+++ b/src/game.jl
@@ -4,7 +4,7 @@
 
 export Game, play!, tournament!
 
-mutable struct Game{T}
+mutable struct Game{T<:Table}
     table::T
 end
 
@@ -17,8 +17,9 @@ function Base.show(io::IO, game::Game)
     println(io, "-----------------------")
 end
 
+Game(players; kwargs...) = Game(Players(players); kwargs...)
 function Game(
-        players::Tuple;
+        players::Players;
         deck = ordered_deck(),
         table = nothing,
         dealer_id::Int = default_dealer_id(),
@@ -41,9 +42,8 @@ function Game(
         @assert length(cards(table)) == 5
         @assert length(deck) + n_player_cards + length(cards(table)) == 52
     else # nobody has been dealt yet
-        table = Table(;
+        table = Table(players;
             deck=deck,
-            players=players,
             dealer_id=dealer_id,
             blinds=blinds,
             logger=logger,
@@ -285,9 +285,8 @@ function reset_game!(game::Game)
     logger = table.logger
     players = players_at_table(table)
 
-    game.table = Table(;
+    game.table = Table(players;
         deck=ordered_deck(),
-        players=players,
         dealer_id=dealer_id(table),
         blinds=table.blinds,
         logger=logger,

--- a/src/player_types.jl
+++ b/src/player_types.jl
@@ -86,3 +86,29 @@ round_bank_roll(player::Player) = player.round_bank_roll
 pot_investment(player::Player) = player.pot_investment
 round_contribution(player::Player) = player.round_contribution
 life_form(player::Player) = player.life_form
+
+
+struct Players{PS<:Union{Tuple,AbstractArray}}
+    players::PS
+end
+
+Base.length(p::Players) = length(p.players)
+Base.iterate(players::Players, state = 1) =
+    Base.iterate(players.players, state)
+Base.@propagate_inbounds Base.getindex(players::Players, i::Int) =
+    Base.getindex(players.players, i)
+Base.filter(fn, players::Players) = Base.filter(fn, players.players)
+
+sorted(players::Players) =
+    Players(sort(collect(players.players); by = x->bank_roll(x)))
+
+#=
+import TupleTools as TT
+# sorted(players::Players) =
+#     Players(map(p->players.players[p], sortperm(players)))
+
+Base.sortperm(players::Players) =
+    TT.sortperm(map(x->bank_roll(x), players.players))
+=#
+
+

--- a/src/table.jl
+++ b/src/table.jl
@@ -50,7 +50,7 @@ buttons(b::Buttons) = (
     b.first_to_act,
 )
 
-mutable struct Table{P, L, TM}
+mutable struct Table{P<:Players, L, TM}
     deck::PlayingCards.Deck
     players::P
     cards::Union{Nothing,Tuple{<:Card,<:Card,<:Card,<:Card,<:Card}}
@@ -96,8 +96,8 @@ function compute_n_max_actions(players, bb)
 end
 n_raises(i, n_players) = Int(floor(i/n_players))
 
-function Table(;
-    players::Tuple,
+Table(players; kwargs...) = Table(Players(players); kwargs...)
+function Table(players::Players;
     deck = ordered_deck(),
     cards = nothing,
     blinds = Blinds(),
@@ -133,7 +133,7 @@ function Table(;
         logger)
 end
 
-function Buttons(dealer_id, players::Tuple)
+function Buttons(dealer_id, players::Players)
     dealer_id       = this_or_next_valid_id(dealer_id       , players)
     small_blind_id  = this_or_next_valid_id(dealer_id     +1, players)
     big_blind_id    = this_or_next_valid_id(small_blind_id+1, players)
@@ -144,12 +144,12 @@ end
 valid_button(player::Player) = !zero_bank_roll(player) && still_playing(player)
 
 """
-    this_or_next_valid_id(id, players::Tuple)
+    this_or_next_valid_id(id, players::Players)
 
 Given an index `id`, return this index, if valid,
 otherwise find the next valid index.
 """
-function this_or_next_valid_id(id, players::Tuple)
+function this_or_next_valid_id(id, players::Players)
     n_players = length(players)
     id = circle_index(n_players, id) # so that we can pass in id+1
     if valid_button(players[id])
@@ -398,7 +398,7 @@ struct BigBlind <: TablePosition end
 struct FirstToAct <: TablePosition end # (after BigBlind)
 
 struct CircleTable{CircType,P, NITER}
-    players::Tuple
+    players::Players
     buttons::Buttons
     n_players::Int
     player::P

--- a/src/transactions.jl
+++ b/src/transactions.jl
@@ -36,8 +36,10 @@ function Base.show(io::IO, tm::TransactionManager, include_type = true)
     println(io, "Pot(s)           = $(tm.side_pots)")
 end
 
-function TransactionManager(players)
-    sorted_players = sort(collect(players); by = x->bank_roll(x))
+TransactionManager(players) = TransactionManager(Players(players))
+function TransactionManager(players::Players)
+#    sorted_players = sort(collect(players); by = x->bank_roll(x))
+    sorted_players = sorted(players)
 
     cap = zeros(length(players))
     for i in 1:length(players)

--- a/test/game.jl
+++ b/test/game.jl
@@ -20,7 +20,7 @@ end
     players = ntuple(3) do i
         Player(Bot5050(), i, pop!(deck, 2))
     end
-    table = Table(;players=players,deck=deck,cards=pop!(deck, 5))
+    table = Table(players;deck=deck,cards=pop!(deck, 5))
     game = Game(players;deck=deck,table=table)
 end
 

--- a/test/table.jl
+++ b/test/table.jl
@@ -11,7 +11,7 @@ TH = TexasHoldem
     shuffle!(deck)
     blinds = TH.Blinds(1,2)
     cards = TH.get_table_cards!(deck)
-    table = TH.Table(;deck=deck, cards=cards, players=players)
+    table = TH.Table(players;deck=deck, cards=cards)
     TH.deal!(table, blinds)
 
     table.state = PreFlop()
@@ -27,7 +27,7 @@ end
 @testset "Table: Move button" begin
     # All players playing
     players = ntuple(i-> Player(Bot5050(), i), 3)
-    table = Table(;players = players)
+    table = Table(players)
     @test TH.buttons(table.buttons) == (1, 2, 3, 1)
     move_buttons!(table)
     @test TH.buttons(table.buttons) == (2, 3, 1, 2)
@@ -42,7 +42,7 @@ end
         Player(Bot5050(), 2; bank_roll=0),
         Player(Bot5050(), 3),
     )
-    table = Table(;players = players)
+    table = Table(players)
     @test TH.buttons(table.buttons) == (1, 3, 1, 3)
     move_buttons!(table)
     @test TH.buttons(table.buttons) == (3, 1, 3, 1)
@@ -57,7 +57,7 @@ end
         Player(Bot5050(), 2; bank_roll=0),
         Player(Bot5050(), 3),
     )
-    table = Table(;players = players, dealer_id=2)
+    table = Table(players; dealer_id=2)
     @test TH.buttons(table.buttons) == (3, 1, 3, 1)
     move_buttons!(table)
     @test TH.buttons(table.buttons) == (1, 3, 1, 3)
@@ -84,7 +84,7 @@ end
 
     # dealer_id = 1
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players)
+    table = Table(players)
     TH.deal!(table, TH.blinds(table))
     iter_players = collect(TH.circle(table, Dealer(), length(players)))
     sn = seat_number.(iter_players)
@@ -92,7 +92,7 @@ end
 
     dealer_id = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players, dealer_id = 2)
+    table = Table(players; dealer_id = 2)
     TH.deal!(table, TH.blinds(table))
     iter_players = collect(TH.circle(table, Dealer(), length(players)))
     sn = seat_number.(iter_players)
@@ -102,7 +102,7 @@ end
 @testset "Table: SmallBlind iterator" begin
     # dealer_id = 1
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players)
+    table = Table(players)
     TH.deal!(table, TH.blinds(table))
     iter_players = collect(TH.circle(table, SmallBlind(), length(players)))
     sn = seat_number.(iter_players)
@@ -110,7 +110,7 @@ end
 
     # dealer_id = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players, dealer_id = 2)
+    table = Table(players; dealer_id = 2)
     TH.deal!(table, TH.blinds(table))
     iter_players = collect(TH.circle(table, SmallBlind(), length(players)))
     sn = seat_number.(iter_players)
@@ -120,7 +120,7 @@ end
 @testset "Table: BigBlind iterator" begin
     # dealer_id = 1
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players)
+    table = Table(players)
     TH.deal!(table, TH.blinds(table))
     iter_players = collect(TH.circle(table, BigBlind(), length(players)))
     sn = seat_number.(iter_players)
@@ -128,7 +128,7 @@ end
 
     # dealer_id = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players, dealer_id = 2)
+    table = Table(players; dealer_id = 2)
     TH.deal!(table, TH.blinds(table))
     iter_players = collect(TH.circle(table, BigBlind(), length(players)))
     sn = seat_number.(iter_players)
@@ -138,7 +138,7 @@ end
 @testset "Table: FirstToAct iterator" begin
     # dealer_id = 1
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players)
+    table = Table(players)
     TH.deal!(table, TH.blinds(table))
     iter_players = collect(TH.circle(table, FirstToAct(), length(players)))
     sn = seat_number.(iter_players)
@@ -146,7 +146,7 @@ end
 
     # dealer_id = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players, dealer_id = 2)
+    table = Table(players; dealer_id = 2)
     TH.deal!(table, TH.blinds(table))
     iter_players = collect(TH.circle(table, FirstToAct(), length(players)))
     sn = seat_number.(iter_players)
@@ -157,7 +157,7 @@ end
     # dealer_id = 1
     @test TH.default_dealer_id() == 1
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players)
+    table = Table(players)
     TH.deal!(table, TH.blinds(table))
     iter_players = collect(TH.circle(table, players[1], length(players)))
     sn = seat_number.(iter_players)
@@ -165,7 +165,7 @@ end
 
     # dealer_id = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players, dealer_id = 2)
+    table = Table(players; dealer_id = 2)
     TH.deal!(table, TH.blinds(table))
     iter_players = collect(TH.circle(table, players[1], length(players)))
     sn = seat_number.(iter_players)
@@ -173,7 +173,7 @@ end
 
     # dealer_id = 1
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players)
+    table = Table(players)
     TH.deal!(table, TH.blinds(table))
     iter_players = collect(TH.circle(table, players[2], length(players)))
     sn = seat_number.(iter_players)
@@ -181,7 +181,7 @@ end
 
     # dealer_id = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(;players = players, dealer_id = 2)
+    table = Table(players; dealer_id = 2)
     TH.deal!(table, TH.blinds(table))
     iter_players = collect(TH.circle(table, players[2], length(players)))
     sn = seat_number.(iter_players)

--- a/test/transactions.jl
+++ b/test/transactions.jl
@@ -11,7 +11,7 @@ TH = TexasHoldem
         Player(Bot5050(), 3, (Q♠, Q♣); bank_roll = 3*100),
     )
     tm = TH.TransactionManager(players)
-    table = Table(;players=players,cards=table_cards,transactions=tm)
+    table = Table(players;cards=table_cards,transactions=tm)
     @test TH.seat_number.(tm.side_pots) == [1,2,3]
 
     TH.raise_to!(table, players[1], 100) # raise all-in
@@ -35,7 +35,7 @@ end
         Player(Bot5050(), 3, (Q♠, Q♣); bank_roll = 1*100),
     )
     tm = TH.TransactionManager(players)
-    table = Table(;players=players,cards=table_cards,transactions=tm)
+    table = Table(players;cards=table_cards,transactions=tm)
 
     TH.raise_to!(table, players[1], 100) # Raise
     TH.call!(table, players[2]) # call
@@ -58,7 +58,7 @@ end
         Player(Bot5050(), 3, (Q♠, Q♣); bank_roll = 3*100),
     )
     tm = TH.TransactionManager(players)
-    table = Table(;players=players,cards=table_cards,transactions=tm)
+    table = Table(players;cards=table_cards,transactions=tm)
 
     TH.raise_to!(table, players[1], 100) # Raise all-in
     TH.call!(table, players[2]) # call
@@ -90,7 +90,7 @@ end
         Player(Bot5050(), 3, (Q♠, Q♣); bank_roll = 1*100),
     )
     tm = TH.TransactionManager(players)
-    table = Table(;players=players,cards=table_cards,transactions=tm)
+    table = Table(players;cards=table_cards,transactions=tm)
 
     TH.raise_to!(table, players[1], 100) # Raise
     TH.call!(table, players[2]) # call
@@ -125,7 +125,7 @@ end
         Player(Bot5050(), 6, (2♠, 3♣); bank_roll = 6*100), # lose, but not bust
     )
     tm = TH.TransactionManager(players)
-    table = Table(;players=players,cards=table_cards,transactions=tm)
+    table = Table(players;cards=table_cards,transactions=tm)
 
     TH.raise_to!(table, players[1], 100) # raise all-in
     TH.call!(table, players[2]) # call
@@ -188,7 +188,7 @@ end
         Player(Bot5050(), 6, (2♠, 3♣); bank_roll = 6*100), # lose, but not bust
     )
     tm = TH.TransactionManager(players)
-    table = Table(;players=players,cards=table_cards,transactions=tm)
+    table = Table(players;cards=table_cards,transactions=tm)
     @test TH.amount.(tm.side_pots) == [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 
     TH.raise_to!(table, players[1], 100) # raise all-in
@@ -232,7 +232,7 @@ end
         Player(Bot5050(), 6, (4♠, 5♣); bank_roll = 1*100), # bust
     )
     tm = TH.TransactionManager(players)
-    table = Table(;players=players,cards=table_cards,transactions=tm)
+    table = Table(players;cards=table_cards,transactions=tm)
     @test TH.amount.(tm.side_pots) == [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 
     TH.raise_to!(table, players[1], 500) # raise to 500


### PR DESCRIPTION
This PR defines `Players`, so that we can extend Base and not have to specialize on things like `<:Tuple{<:Player}`.

I've also changed the `Table` interface to accept `Union{Tuple,Players}` as a positional argument, which is unfortunately breaking but it's more consistent with `Game`.