### PR TITLE
Refactor

### DIFF
--- a/src/TexasHoldem.jl
+++ b/src/TexasHoldem.jl
@@ -28,6 +28,7 @@ struct Turn <: AbstractGameState end
 struct River <: AbstractGameState end
 
 include("player_types.jl")
+include("players.jl")
 include("transactions.jl")
 include("table.jl")
 include("game.jl")

--- a/src/game.jl
+++ b/src/game.jl
@@ -161,6 +161,7 @@ end
 
 function act_generic!(game::Game, state::AbstractGameState)
     table = game.table
+    players = table.players
     logger = table.logger
     table.winners.declared && return
     set_state!(table, state)
@@ -170,7 +171,8 @@ function act_generic!(game::Game, state::AbstractGameState)
     any_actions_required(game) || return
     play_out_game(table) && return
     set_play_out_game!(table)
-    for (i, player) in enumerate(circle(table, FirstToAct()))
+    for (i, sn) in enumerate(circle(table, FirstToAct()))
+        player = players[sn]
         @cdebug logger "Checking to see if it's $(name(player))'s turn to act"
         @cdebug logger "     not_playing(player) = $(not_playing(player))"
         @cdebug logger "     all_in(player) = $(all_in(player))"

--- a/src/player_types.jl
+++ b/src/player_types.jl
@@ -87,28 +87,3 @@ pot_investment(player::Player) = player.pot_investment
 round_contribution(player::Player) = player.round_contribution
 life_form(player::Player) = player.life_form
 
-
-struct Players{PS<:Union{Tuple,AbstractArray}}
-    players::PS
-end
-
-Base.length(p::Players) = length(p.players)
-Base.iterate(players::Players, state = 1) =
-    Base.iterate(players.players, state)
-Base.@propagate_inbounds Base.getindex(players::Players, i::Int) =
-    Base.getindex(players.players, i)
-Base.filter(fn, players::Players) = Base.filter(fn, players.players)
-
-sorted(players::Players) =
-    Players(sort(collect(players.players); by = x->bank_roll(x)))
-
-#=
-import TupleTools as TT
-# sorted(players::Players) =
-#     Players(map(p->players.players[p], sortperm(players)))
-
-Base.sortperm(players::Players) =
-    TT.sortperm(map(x->bank_roll(x), players.players))
-=#
-
-

--- a/src/players.jl
+++ b/src/players.jl
@@ -1,0 +1,25 @@
+struct Players{PS<:Union{Tuple,AbstractArray}}
+    players::PS
+end
+
+Base.length(p::Players) = length(p.players)
+Base.iterate(players::Players, state = 1) =
+    Base.iterate(players.players, state)
+Base.@propagate_inbounds Base.getindex(players::Players, i::Int) =
+    Base.getindex(players.players, i)
+Base.filter(fn, players::Players) = Base.filter(fn, players.players)
+
+sorted(players::Players) =
+    Players(sort(collect(players.players); by = x->bank_roll(x)))
+n_players(players::Players) = length(players)
+
+#=
+import TupleTools as TT
+# sorted(players::Players) =
+#     Players(map(p->players.players[p], sortperm(players)))
+
+Base.sortperm(players::Players) =
+    TT.sortperm(map(x->bank_roll(x), players.players))
+=#
+
+

--- a/test/table.jl
+++ b/test/table.jl
@@ -86,17 +86,15 @@ end
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(players)
     TH.deal!(table, TH.blinds(table))
-    iter_players = collect(TH.circle(table, Dealer(), length(players)))
-    sn = seat_number.(iter_players)
-    @test sn == [1, 2, 3, 4, 5]
+    ind = collect(TH.circle(table, Dealer(), length(players)))
+    @test ind == [1, 2, 3, 4, 5]
 
     dealer_id = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(players; dealer_id = 2)
     TH.deal!(table, TH.blinds(table))
-    iter_players = collect(TH.circle(table, Dealer(), length(players)))
-    sn = seat_number.(iter_players)
-    @test sn == [2, 3, 4, 5, 1]
+    ind = collect(TH.circle(table, Dealer(), length(players)))
+    @test ind == [2, 3, 4, 5, 1]
 end
 
 @testset "Table: SmallBlind iterator" begin
@@ -104,17 +102,15 @@ end
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(players)
     TH.deal!(table, TH.blinds(table))
-    iter_players = collect(TH.circle(table, SmallBlind(), length(players)))
-    sn = seat_number.(iter_players)
-    @test sn == [2, 3, 4, 5, 1]
+    ind = collect(TH.circle(table, SmallBlind(), length(players)))
+    @test ind == [2, 3, 4, 5, 1]
 
     # dealer_id = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(players; dealer_id = 2)
     TH.deal!(table, TH.blinds(table))
-    iter_players = collect(TH.circle(table, SmallBlind(), length(players)))
-    sn = seat_number.(iter_players)
-    @test sn == [3, 4, 5, 1, 2]
+    ind = collect(TH.circle(table, SmallBlind(), length(players)))
+    @test ind == [3, 4, 5, 1, 2]
 end
 
 @testset "Table: BigBlind iterator" begin
@@ -122,17 +118,15 @@ end
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(players)
     TH.deal!(table, TH.blinds(table))
-    iter_players = collect(TH.circle(table, BigBlind(), length(players)))
-    sn = seat_number.(iter_players)
-    @test sn == [3, 4, 5, 1, 2]
+    ind = collect(TH.circle(table, BigBlind(), length(players)))
+    @test ind == [3, 4, 5, 1, 2]
 
     # dealer_id = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(players; dealer_id = 2)
     TH.deal!(table, TH.blinds(table))
-    iter_players = collect(TH.circle(table, BigBlind(), length(players)))
-    sn = seat_number.(iter_players)
-    @test sn == [4, 5, 1, 2, 3]
+    ind = collect(TH.circle(table, BigBlind(), length(players)))
+    @test ind == [4, 5, 1, 2, 3]
 end
 
 @testset "Table: FirstToAct iterator" begin
@@ -140,50 +134,13 @@ end
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(players)
     TH.deal!(table, TH.blinds(table))
-    iter_players = collect(TH.circle(table, FirstToAct(), length(players)))
-    sn = seat_number.(iter_players)
-    @test sn == [4, 5, 1, 2, 3]
+    ind = collect(TH.circle(table, FirstToAct(), length(players)))
+    @test ind == [4, 5, 1, 2, 3]
 
     # dealer_id = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(players; dealer_id = 2)
     TH.deal!(table, TH.blinds(table))
-    iter_players = collect(TH.circle(table, FirstToAct(), length(players)))
-    sn = seat_number.(iter_players)
-    @test sn == [5, 1, 2, 3, 4]
-end
-
-@testset "Table: iterate from player" begin
-    # dealer_id = 1
-    @test TH.default_dealer_id() == 1
-    players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(players)
-    TH.deal!(table, TH.blinds(table))
-    iter_players = collect(TH.circle(table, players[1], length(players)))
-    sn = seat_number.(iter_players)
-    @test sn == [1, 2, 3, 4, 5]
-
-    # dealer_id = 2
-    players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(players; dealer_id = 2)
-    TH.deal!(table, TH.blinds(table))
-    iter_players = collect(TH.circle(table, players[1], length(players)))
-    sn = seat_number.(iter_players)
-    @test sn == [1, 2, 3, 4, 5]
-
-    # dealer_id = 1
-    players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(players)
-    TH.deal!(table, TH.blinds(table))
-    iter_players = collect(TH.circle(table, players[2], length(players)))
-    sn = seat_number.(iter_players)
-    @test sn == [2, 3, 4, 5, 1]
-
-    # dealer_id = 2
-    players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(players; dealer_id = 2)
-    TH.deal!(table, TH.blinds(table))
-    iter_players = collect(TH.circle(table, players[2], length(players)))
-    sn = seat_number.(iter_players)
-    @test sn == [2, 3, 4, 5, 1]
+    ind = collect(TH.circle(table, FirstToAct(), length(players)))
+    @test ind == [5, 1, 2, 3, 4]
 end


### PR DESCRIPTION
This PR:
 - Uses more concrete types in CircleTable
 - Removes unused methods (simulating games does not rely on circling from specific players, only from specific positions)
 - Removes the corresponding tests
 - Remove the unused type parameters
 - Makes `circle` return the player's index, instead of the player, which makes the iterator type-stable.