### PR TITLE
Avoid materializing, more concrete types

### DIFF
--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -22,7 +22,7 @@ players() = ntuple(i->(Player(BotCheckCall(), i)), 4)
 # very close in benchmark times.
 function do_work!()
     Logging.with_logger(Logging.NullLogger()) do
-        play!(Game(players()))
+        play!(Game(players();logger=TH.ByPassLogger()))
     end
     return nothing
 end

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -28,10 +28,10 @@ end
 import Profile
 import ProfileCanvas
 
-games = map(x->Game(players()), 1:10000);
+games = map(x->Game(players();logger=TH.ByPassLogger()), 1:10000);
 do_work!(games) # compile first
 
-games = map(x->Game(players()), 1:10000);
+games = map(x->Game(players();logger=TH.ByPassLogger()), 1:10000);
 Profile.clear()
 prof = Profile.@profile begin
     do_work!(games)

--- a/src/game.jl
+++ b/src/game.jl
@@ -101,7 +101,7 @@ function end_of_actions(table::Table, player)
     case_3 = all_playing_all_in(table)
     case_4 = all_all_in_except_bank_roll_leader(table)
     case_5 = all_all_in_or_checked(table) # TODO: likely replaceable with case_6
-    case_6 = !any(action_required.(players))
+    case_6 = !any(x->action_required(x), players)
     case_7 = all_oppononents_all_in(table, player) && paid_current_raise_amount(table, player)
     @cdebug logger "     cases = $((case_1, case_2, case_3, case_4, case_5, case_6, case_7))"
 

--- a/src/table.jl
+++ b/src/table.jl
@@ -50,11 +50,11 @@ buttons(b::Buttons) = (
     b.first_to_act,
 )
 
-mutable struct Table{P<:Players, L, TM}
+mutable struct Table{P<:Players, L, TM, B <: Blinds}
     deck::PlayingCards.Deck
     players::P
     cards::Union{Nothing,Tuple{<:Card,<:Card,<:Card,<:Card,<:Card}}
-    blinds::Blinds
+    blinds::B
     pot::Float64
     state::AbstractGameState
     buttons::Buttons
@@ -117,7 +117,8 @@ function Table(players::Players;
     @cdebug logger "n_max_actions = $n_max_actions"
     L = typeof(logger)
     TM = typeof(transactions)
-    return Table{P, L, TM}(deck,
+    B = typeof(blinds)
+    return Table{P, L, TM, B}(deck,
         players,
         cards,
         blinds,

--- a/src/transactions.jl
+++ b/src/transactions.jl
@@ -195,7 +195,7 @@ end
 function distribute_winnings!(players, tm::TransactionManager, table_cards, logger=StandardLogger())
     @cdebug logger "Distributing winnings..."
     @cdebug logger "Pot amounts = $(amount.(tm.side_pots))"
-    if count(still_playing.(players)) == 1
+    if count(x->still_playing(x), players) == 1
         return distribute_winnings_1_player_left!(players, tm, table_cards, logger)
     end
     hand_evals_sorted = map(enumerate(tm.sorted_players)) do (ssn, player)


### PR DESCRIPTION
This PR avoids materializing and more concrete types. It also changes our perf measurements to use the `ByPassLogger`, so that we avoid performance hits from using the logger.

We're down to ~20μs/game with this PR.