### PR TITLE
Improve names

### DIFF
--- a/src/TexasHoldem.jl
+++ b/src/TexasHoldem.jl
@@ -6,7 +6,7 @@ A no-limit Texas Holdem simulator.
 # Terminology
  - `game` a single "game", where players are dealt hands,
    winner(s) are declared once.
- - `state` a point or process in the game, including
+ - `stage` a point or process in the game, including
    `PreFlop`, `Flop`, `Turn`, `River`.
  - `round` the process of each player deciding which
    actions to take, until no further actions are taking.
@@ -17,15 +17,15 @@ using PlayingCards
 using PokerHandEvaluator
 using Printf
 
-export AbstractGameState, PreFlop, Flop, Turn, River
+export AbstractGameStage, PreFlop, Flop, Turn, River
 
 include("custom_logger.jl")
 
-abstract type AbstractGameState end
-struct PreFlop <: AbstractGameState end
-struct Flop <: AbstractGameState end
-struct Turn <: AbstractGameState end
-struct River <: AbstractGameState end
+abstract type AbstractGameStage end
+struct PreFlop <: AbstractGameStage end
+struct Flop <: AbstractGameStage end
+struct Turn <: AbstractGameStage end
+struct River <: AbstractGameStage end
 
 include("player_types.jl")
 include("players.jl")

--- a/src/player_options.jl
+++ b/src/player_options.jl
@@ -65,9 +65,9 @@ function player_option!(game::Game, player::Player)
 end
 
 # By default, forward to `player_option!` with
-# game state:
+# game stage:
 player_option!(game::Game, player::Player, option) =
-    player_option!(game, player, state(game.table), option)
+    player_option!(game, player, stage(game.table), option)
 
 #####
 ##### Human player options (ask via prompts)

--- a/src/players.jl
+++ b/src/players.jl
@@ -1,10 +1,47 @@
+"""
+    Players
+
+A collection of players. This collection may
+be a Tuple or a vector:
+
+    (player[1], player[2], player[3])
+    [player[1], player[2], player[3]]
+
+These indices correspond to the player index (`pidx`).
+
+Both the player's seat number and index
+must be unique, but they need not be equal:
+
+    pidx                 : (player[1], player[2], player[3])
+    seat_number.(players): (   6     ,    3     ,    2     )
+
+Also, the seat number need not be consecutive
+when sorted, whereas the player indexes must
+be consecutive when sorted.
+
+Since players are allowed to have different
+composition, we provide iterators over the
+players index, rather than the players
+themselves, for type-stability.
+"""
 struct Players{PS<:Union{Tuple,AbstractArray}}
     players::PS
 end
 
+"""
+    cyclic_player_index(::Players, pidx)
+    cyclic_player_index(n_players, pidx)
+
+A circular index for indexing into `players`.
+`pidx = 1` corresponds to `player[1]`.
+"""
+cyclic_player_index(players::Players, i) =
+    cyclic_player_index(length(players.players), i)
+cyclic_player_index(n_players, i) = mod(i-1, n_players)+1
+
 Base.length(p::Players) = length(p.players)
-Base.iterate(players::Players, state = 1) =
-    Base.iterate(players.players, state)
+Base.iterate(players::Players, ncpidx = 1) =
+    Base.iterate(players.players, ncpidx)
 Base.@propagate_inbounds Base.getindex(players::Players, i::Int) =
     Base.getindex(players.players, i)
 Base.filter(fn, players::Players) = Base.filter(fn, players.players)

--- a/test/call_raise_validation.jl
+++ b/test/call_raise_validation.jl
@@ -165,14 +165,14 @@ end
 
     players = (Player(Human(), 1), Player(Bot5050(), 2))
     table = Game(players).table
-    table.state = Flop()
+    table.stage = Flop()
     table.current_raise_amt = 10
     players[1].round_contribution = 10
     @test call_amount(table, players[1]) == 0.0
 
     players = (Player(Human(), 1), Player(Bot5050(), 2))
     table = Game(players).table
-    table.state = Flop()
+    table.stage = Flop()
     table.current_raise_amt = 10
     players[1].round_contribution = 20
     @test_throws AssertionError("Call amount cannot be negative") call_amount(table, players[1])

--- a/test/game.jl
+++ b/test/game.jl
@@ -10,7 +10,7 @@ TH = TexasHoldem
     game = Game(players)
     sprint(show, game)
 
-    game.table.state = PreFlop()
+    game.table.stage = PreFlop()
     sprint(show, game)
 end
 

--- a/test/play.jl
+++ b/test/play.jl
@@ -31,7 +31,7 @@ end
 
 struct NoActionBot <: AbstractAI end
 
-TH.player_option!(game::Game, player::Player{NoActionBot}, ::AbstractGameState, ::PlayerOptions) = nothing
+TH.player_option!(game::Game, player::Player{NoActionBot}, ::AbstractGameStage, ::PlayerOptions) = nothing
 
 @testset "Game: Play (NoActionBot)" begin
     game = Game((Player(BotCheckCall(), 1), Player(NoActionBot(), 2),))
@@ -104,7 +104,7 @@ n_call_actions = [0]
         Player(BotNActions(), 3),
         Player(BotNActions(), 4; bank_roll = 0),
         Player(BotNActions(), 5),
-    ); dealer_id = 1))
+    ); dealer_pidx = 1))
 
     @test n_call_actions[1] == 2 # dealer + small blind
     # 1 check pre-flop (big blind)
@@ -126,7 +126,7 @@ n_call_actions = [0]
         Player(BotPreFlopRaise(7.0), 3; bank_roll = 256.0),
         Player(BotCheckCall(), 4; bank_roll = 4.0),
         Player(BotCheckFold(), 5; bank_roll = 45.0),
-    ); dealer_id = 1))
+    ); dealer_pidx = 1))
 
     @test n_call_actions[1] == 2 # dealer + small blind
     # 1 check pre-flop (big blind)

--- a/test/table.jl
+++ b/test/table.jl
@@ -14,13 +14,13 @@ TH = TexasHoldem
     table = TH.Table(players;deck=deck, cards=cards)
     TH.deal!(table, blinds)
 
-    table.state = PreFlop()
+    table.stage = PreFlop()
     @test TH.observed_cards(table) == ()
-    table.state = Flop()
+    table.stage = Flop()
     @test TH.observed_cards(table) == table.cards[1:3]
-    table.state = Turn()
+    table.stage = Turn()
     @test TH.observed_cards(table) == table.cards[1:4]
-    table.state = River()
+    table.stage = River()
     @test TH.observed_cards(table) == table.cards
 end
 
@@ -57,7 +57,7 @@ end
         Player(Bot5050(), 2; bank_roll=0),
         Player(Bot5050(), 3),
     )
-    table = Table(players; dealer_id=2)
+    table = Table(players; dealer_pidx=2)
     @test TH.buttons(table.buttons) == (3, 1, 3, 1)
     move_buttons!(table)
     @test TH.buttons(table.buttons) == (1, 3, 1, 3)
@@ -67,79 +67,79 @@ end
     @test TH.buttons(table.buttons) == (1, 3, 1, 3)
 end
 
-@testset "Table: Circle index" begin
-    @test TH.circle_index(5, 1) == 1
-    @test TH.circle_index(5, 2) == 2
-    @test TH.circle_index(5, 3) == 3
-    @test TH.circle_index(5, 4) == 4
-    @test TH.circle_index(5, 5) == 5
-    @test TH.circle_index(5, 6) == 1
-    @test TH.circle_index(5, 7) == 2
-    @test TH.circle_index(5, 0) == 5
-    @test TH.circle_index(5, -1) == 4
+@testset "Players: cyclic player index (pidx)" begin
+    @test TH.cyclic_player_index(5, 1) == 1
+    @test TH.cyclic_player_index(5, 2) == 2
+    @test TH.cyclic_player_index(5, 3) == 3
+    @test TH.cyclic_player_index(5, 4) == 4
+    @test TH.cyclic_player_index(5, 5) == 5
+    @test TH.cyclic_player_index(5, 6) == 1
+    @test TH.cyclic_player_index(5, 7) == 2
+    @test TH.cyclic_player_index(5, 0) == 5
+    @test TH.cyclic_player_index(5, -1) == 4
 end
 
 @testset "Table: Dealer iterator" begin
-    @test TH.default_dealer_id() == 1
+    @test TH.default_dealer_pidx() == 1
 
-    # dealer_id = 1
+    # dealer_pidx = 1
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(players)
     TH.deal!(table, TH.blinds(table))
     ind = collect(TH.circle(table, Dealer(), length(players)))
     @test ind == [1, 2, 3, 4, 5]
 
-    dealer_id = 2
+    dealer_pidx = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(players; dealer_id = 2)
+    table = Table(players; dealer_pidx = 2)
     TH.deal!(table, TH.blinds(table))
     ind = collect(TH.circle(table, Dealer(), length(players)))
     @test ind == [2, 3, 4, 5, 1]
 end
 
 @testset "Table: SmallBlind iterator" begin
-    # dealer_id = 1
+    # dealer_pidx = 1
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(players)
     TH.deal!(table, TH.blinds(table))
     ind = collect(TH.circle(table, SmallBlind(), length(players)))
     @test ind == [2, 3, 4, 5, 1]
 
-    # dealer_id = 2
+    # dealer_pidx = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(players; dealer_id = 2)
+    table = Table(players; dealer_pidx = 2)
     TH.deal!(table, TH.blinds(table))
     ind = collect(TH.circle(table, SmallBlind(), length(players)))
     @test ind == [3, 4, 5, 1, 2]
 end
 
 @testset "Table: BigBlind iterator" begin
-    # dealer_id = 1
+    # dealer_pidx = 1
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(players)
     TH.deal!(table, TH.blinds(table))
     ind = collect(TH.circle(table, BigBlind(), length(players)))
     @test ind == [3, 4, 5, 1, 2]
 
-    # dealer_id = 2
+    # dealer_pidx = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(players; dealer_id = 2)
+    table = Table(players; dealer_pidx = 2)
     TH.deal!(table, TH.blinds(table))
     ind = collect(TH.circle(table, BigBlind(), length(players)))
     @test ind == [4, 5, 1, 2, 3]
 end
 
 @testset "Table: FirstToAct iterator" begin
-    # dealer_id = 1
+    # dealer_pidx = 1
     players = ntuple(i-> Player(Bot5050(), i), 5)
     table = Table(players)
     TH.deal!(table, TH.blinds(table))
     ind = collect(TH.circle(table, FirstToAct(), length(players)))
     @test ind == [4, 5, 1, 2, 3]
 
-    # dealer_id = 2
+    # dealer_pidx = 2
     players = ntuple(i-> Player(Bot5050(), i), 5)
-    table = Table(players; dealer_id = 2)
+    table = Table(players; dealer_pidx = 2)
     TH.deal!(table, TH.blinds(table))
     ind = collect(TH.circle(table, FirstToAct(), length(players)))
     @test ind == [5, 1, 2, 3, 4]

--- a/test/tester_bots.jl
+++ b/test/tester_bots.jl
@@ -5,7 +5,7 @@
 using TexasHoldem
 import TexasHoldem
 TH = TexasHoldem
-const AGS = AbstractGameState
+const AGS = AbstractGameStage
 
 ##### BotCheckFold
 struct BotCheckFold <: AbstractAI end

--- a/test/transactions.jl
+++ b/test/transactions.jl
@@ -1,6 +1,6 @@
 using Test
 using PlayingCards
-using TexasHoldem: Player, Bot5050, TransactionManager, dealer_id, Table
+using TexasHoldem: Player, Bot5050, TransactionManager, dealer_pidx, Table
 TH = TexasHoldem
 
 @testset "TransactionManagers - Lowest bank roll goes all-in and wins it all" begin


### PR DESCRIPTION
This PR:
 - Changes the game `state` to `stage` (for now). We'll want to add a proper game state (#132)
 - Add docs to clarify distinction between the player seat number, index, cyclic index and non-cyclic index. This really helps improve readability and simplicity since sometimes we used `id`, `state` `i_circ` (`circle_index`).

Next, we can apply similar name improvements to the transactions section.