### PR TITLE
Remove winning players from winners

### DIFF
--- a/src/game.jl
+++ b/src/game.jl
@@ -249,7 +249,7 @@ function play!(game::Game)
     winners.declared || act!(game, Turn())      # Deal turn , then bet/check/raise
     winners.declared || act!(game, River())     # Deal river, then bet/check/raise
 
-    winners.players = distribute_winnings!(players, table.transactions, cards(table), logger)
+    distribute_winnings!(players, table.transactions, cards(table), logger)
     winners.declared = true
 
     @cdebug logger "amount.(table.transactions.side_pots) = $(amount.(table.transactions.side_pots))"

--- a/src/table.jl
+++ b/src/table.jl
@@ -8,13 +8,11 @@ export move_buttons!
 
 Base.@kwdef mutable struct Winners
     declared::Bool = false
-    players::Union{Nothing,Tuple,Player} = nothing
 end
 
 function Base.show(io::IO, winners::Winners, include_type = true)
     include_type && println(io, typeof(winners))
     println(io, "Winners declared = $(winners.declared)")
-    println(io, "Winners          = $(winners.players)")
 end
 
 struct Blinds{S,B}
@@ -344,12 +342,7 @@ function check_for_and_declare_winner!(table::Table)
     players = players_at_table(table)
     n_players = length(players)
     table.winners.declared = count(not_playing.(players)) == n_players-1
-    if table.winners.declared
-        for player in players
-            not_playing(player) && continue
-            table.winners.players = player
-        end
-    end
+    return nothing
 end
 
 

--- a/src/transactions.jl
+++ b/src/transactions.jl
@@ -232,7 +232,6 @@ function distribute_winnings!(players, tm::TransactionManager, table_cards, logg
         zeros(length(tm.side_pots))
     end
     winning_hands = Vector{Symbol}(undef, length(players))
-    all_winning_players = Player[]
 
     @inbounds for i in 1:length(tm.side_pots)
         sidepot_winnings(tm, length(players)) ≈ 0 && continue # no money left to distribute
@@ -270,7 +269,6 @@ function distribute_winnings!(players, tm::TransactionManager, table_cards, logg
             win_seat = seat_number(tm.sorted_players[winner_id])
             winning_player = players[win_seat]
             not_playing(winning_player) && continue
-            push!(all_winning_players, winning_player)
             amt = sidepot_winnings(tm, i) / n_winners
             side_pot_winnings[win_seat][i] = amt
             winning_hands[win_seat] = hand_type(hand_evals_sorted[winner_id].fhe)
@@ -303,5 +301,5 @@ function distribute_winnings!(players, tm::TransactionManager, table_cards, logg
     end
 
     @cdebug logger "Distributed winnings..."
-    return Tuple(all_winning_players)
+    return nothing
 end


### PR DESCRIPTION
Doing this is type unstable, and we can inform winners that they've won a game in a much more lightweight way (e.g., look at their bank roll)