### PR TITLE
Use sortperm instead of sorting players

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ PlayingCards = "ecfe714a-bcc2-4d11-ad00-25525ff8f984"
 PokerHandEvaluator = "18ed25b1-892a-4a3b-b8fc-1036dc9a6a89"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 
 [compat]
 PlayingCards = "0.3.1"

--- a/src/players.jl
+++ b/src/players.jl
@@ -56,13 +56,17 @@ sorted_collect(players::Players) =
     Players(sort(collect(players.players); by = x->bank_roll(x)))
 n_players(players::Players) = length(players)
 
+import TupleTools
+Base.sortperm(players::Players{<:AbstractArray}) =
+    Base.sortperm(map(x->bank_roll(x), players.players))
+
+Base.sortperm(players::Players{<:Tuple}) =
+    TupleTools.sortperm(map(x->bank_roll(x), players.players))
+
 #=
-import TupleTools as TT
 # sorted(players::Players) =
 #     Players(map(p->players.players[p], sortperm(players)))
 
-Base.sortperm(players::Players) =
-    TT.sortperm(map(x->bank_roll(x), players.players))
 =#
 
 


### PR DESCRIPTION
This PR removes `sorted_players` in place of using `sortperm`, since this is type stable