### PR TITLE
Improve fuzzing

### DIFF
--- a/test/fuzz_play.jl
+++ b/test/fuzz_play.jl
@@ -1,114 +1,29 @@
-using Test
-using PlayingCards
-using TexasHoldem
-import Random
-import Logging
-
-metafmt(level, _module, group, id, file, line) =
-    Logging.default_metafmt(level, nothing, group, id, nothing, nothing)
-
-function get_games(players, n_games)
-    return map(1:n_games) do x
-        # if x==2098 # useful for debugging games
-        #     Game(deepcopy(players);logger=TexasHoldem.StandardLogger())
-        # else
-            Game(deepcopy(players);logger=TexasHoldem.ByPassLogger())
-        # end
-    end
-end
-
-#=This unfortunately doesn't seem to generate/replay the same exact games=#
-function replay_with_debugger(crashes, e;fun,n_players, n_games, bank_roll)
-    if !isempty(crashes)
-        @show first(crashes)
-        Random.seed!(1234)
-        players = ntuple(i->Player(Bot5050(), i; bank_roll), n_players)
-        games = get_games(players, n_games)
-        logger = Logging.ConsoleLogger(stderr,Logging.Debug;meta_formatter=metafmt)
-        Logging.with_logger(logger) do
-            fun(games[first(crashes)])
-        end
-    end
-    rethrow(e)
-end
-
-function fuzz(;fun,n_players, n_games, bank_roll=200)
-    Random.seed!(1234)
-    players = ntuple(i->Player(Bot5050(), i; bank_roll), n_players)
-    # games = map(x->Game(deepcopy(players);logger=TexasHoldem.ByPassLogger()), 1:n_games)
-    games = get_games(players, n_games)
-    crashes = Int[]
-    for n in 1:length(games)
-        # try
-            game = games[n]
-            if game.table.logger isa TexasHoldem.ByPassLogger
-                fun(game)
-            else
-                logger = Logging.ConsoleLogger(stderr,Logging.Debug;meta_formatter=metafmt)
-                Logging.with_logger(logger) do
-                    fun(game)
-                end
-            end
-        # catch e
-        #     push!(crashes, n)
-        #     @show first(crashes) # print the n-th game that is failing
-        #     # ideally, we would replay the game, but this doesn't seem to work.
-        #     # Leaving this commented out in hopes that we can get this working.
-        #     replay_with_debugger(crashes, e;fun,n_players, n_games, bank_roll)
-        # end
-    end
-    # @test isempty(crashes)
-end
-
-function fuzz_working(;fun,n_players, n_games, bank_roll=200)
-    Random.seed!(1234)
-    players = ntuple(i->Player(Bot5050(), i; bank_roll), n_players)
-    games = map(x->Game(deepcopy(players);logger=TexasHoldem.ByPassLogger()), 1:n_games)
-    crashes = Int[]
-    for n in 1:length(games)
-        try
-            fun(games[n])
-        catch e
-            push!(crashes, n)
-            replay_with_debugger(crashes, e;fun,n_players, n_games, bank_roll)
-        end
-    end
-    @test isempty(crashes)
-end
+include("fuzz_utils.jl")
 
 @testset "Game: play! (3 Bot5050's)" begin
-    fuzz_working(;fun=play!,n_players=3, n_games=100_000)
+    @test isempty(fuzz(;fun=play!,n_players=3, bank_roll=200, n_games=100_000))
 end
 
 @testset "Game: play! (10 Bot5050's)" begin
-    fuzz_working(;fun=play!,n_players=10, n_games=10_000)
+    @test isempty(fuzz(;fun=play!,n_players=10, bank_roll=200, n_games=10_000))
 end
 
 @testset "Game: tournament! (2 Bot5050's)" begin
-    fuzz_working(;fun=tournament!,n_players=2, bank_roll = 6, n_games=10_000)
+    @test isempty(fuzz(;fun=tournament!,n_players=2, bank_roll=6, n_games=10_000))
+    @test isempty(fuzz(;fun=tournament!,n_players=2, bank_roll=30,n_games=100_000))
 end
 
 @testset "Game: tournament! (3 Bot5050's)" begin
-    fuzz_working(;fun=tournament!,n_players=3, bank_roll = 6, n_games=10_000)
+    @test isempty(fuzz(;fun=tournament!,n_players=3, bank_roll=6,  n_games=10_000))
+    @test isempty(fuzz(;fun=tournament!,n_players=3, bank_roll=30, n_games=100_000))
 end
 
 @testset "Game: tournament! (10 Bot5050's)" begin
-    fuzz(;fun=tournament!,n_players=10, bank_roll = 6, n_games=1_000)
+    @test_broken isempty(fuzz(;fun=tournament!,n_players=10,bank_roll=30,n_games=3788))
 end
 
 #=
-
-This fails:
-@testset "Game: tournament! (2 Bot5050's)" begin
-    fuzz_working(;fun=tournament!,n_players=2, bank_roll = 30, n_games=10_000)
-end
-
-@testset "Game: tournament! (3 Bot5050's)" begin
-    fuzz_working(;fun=tournament!,n_players=3, bank_roll = 30, n_games=10_000)
-end
-
-@testset "Game: tournament! (10 Bot5050's)" begin
-    fuzz(;fun=tournament!,n_players=10, bank_roll = 30, n_games=10_000)
-end
-
+Breaking cases:
+fuzz_debug(;fun=tournament!,n_players=10,bank_roll=30,n_games=3788)
 =#
+

--- a/test/fuzz_utils.jl
+++ b/test/fuzz_utils.jl
@@ -1,0 +1,69 @@
+using Test
+using PlayingCards
+using TexasHoldem
+import Random
+import Logging
+
+metafmt(level, _module, group, id, file, line) =
+    Logging.default_metafmt(level, nothing, group, id, nothing, nothing)
+
+#=
+Make a collection of games, run them,
+and if any fail, return the indices of
+the games that fail. This is helpful
+to enforce tests that work.
+=#
+function fuzz(;fun,n_players, n_games, bank_roll=200)
+    Random.seed!(1234)
+    players = ntuple(i->Player(Bot5050(), i; bank_roll), n_players)
+    games = map(x-> Game(deepcopy(players);logger=TexasHoldem.ByPassLogger()), 1:n_games)
+    crashes = Int[]
+    for n in 1:length(games)
+        try
+            fun(games[n])
+        catch
+            push!(crashes, n)
+        end
+    end
+    return crashes
+end
+
+function get_games(; n_games, crashes, players)
+    return map(1:n_games) do x
+        logger = x in crashes ? TexasHoldem.StandardLogger() : TexasHoldem.ByPassLogger()
+        Game(deepcopy(players);logger)
+    end
+end
+
+#=
+Run a collection of games, if they fail,
+re-run the exact same collection, except:
+swap the logger to debug level for the
+indices that fail.
+=#
+function fuzz_debug(;fun,n_players, n_games, bank_roll=200)
+    crashes = fuzz(;fun,n_players, n_games, bank_roll)
+    Random.seed!(1234)
+    players = ntuple(i->Player(Bot5050(), i; bank_roll), n_players)
+    @time begin
+        games = get_games(; n_games, crashes, players)
+    end
+    for n in 1:length(games)
+        try
+            game = games[n]
+            if game.table.logger isa TexasHoldem.ByPassLogger
+                fun(game)
+            else
+                logger = Logging.ConsoleLogger(stderr,Logging.Debug;meta_formatter=metafmt)
+                Logging.with_logger(logger) do
+                    fun(game)
+                end
+            end
+        catch e
+            rethrow(e)
+            break
+        end
+    end
+    error("Caught and printed debug info, n_crashes found: $(length(crashes))")
+    return crashes
+end


### PR DESCRIPTION
This PR finishes up what #145 missed: when trying to recreate a breaking game, we need to replay all games leading up to that game because the random numbers that are sampled leading to the breaking game must be sampled!

This should make fuzz debugging way easier.