### PR TITLE
Remove action history

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ tournament!(configure_game()) # play until 1 player remains
 
 # Creating your own bot
 
-Four methods (variants of `player_option!`) need to be defined to create and play your own bot:
+Four methods (variants of `player_option`) need to be defined to create and play your own bot:
 
 ```julia
 using TexasHoldem
@@ -48,61 +48,61 @@ import TexasHoldem as TH
 
 struct MyBot <: AbstractAI end
 
-function TH.player_option!(game::Game, player::Player{MyBot}, ::CheckRaiseFold)
+function TH.player_option(game::Game, player::Player{MyBot}, ::CheckRaiseFold)
     # options are:
-    #    check!(game, player)
+    #    check(game, player)
     #    raise!(game, player, amt::Real)
-    #    raise_all_in!(game, player)
-    #    fold!(game, player)
+    #    raise_all_in(game, player)
+    #    fold(game, player)
     if rand() < 0.5
-        check!(game, player)
+        check(game, player)
     else
         amt = Int(round(rand()*bank_roll(player), digits=0))
         amt = TH.bound_raise(game.table, player, amt) # to properly bound raise amount
-        raise_to!(game, player, amt)
+        raise_to(game, player, amt)
     end
 end
-function TH.player_option!(game::Game, player::Player{MyBot}, ::CallRaiseFold)
+function TH.player_option(game::Game, player::Player{MyBot}, ::CallRaiseFold)
     # options are:
-    #    call!(game, player)
+    #    call(game, player)
     #    raise!(game, player, amt::Real)
-    #    raise_all_in!(game, player)
-    #    fold!(game, player)
+    #    raise_all_in(game, player)
+    #    fold(game, player)
     if rand() < 0.5
         if rand() < 0.5 # Call
-            call!(game, player)
+            call(game, player)
         else # re-raise
             amt = Int(round(rand()*bank_roll(player), digits=0))
             amt = TH.bound_raise(game.table, player, amt) # to properly bound raise amount
-            raise_to!(game, player, amt)
+            raise_to(game, player, amt)
         end
     else
-        fold!(game, player)
+        fold(game, player)
     end
 end
-function TH.player_option!(game::Game, player::Player{MyBot}, ::CallAllInFold)
+function TH.player_option(game::Game, player::Player{MyBot}, ::CallAllInFold)
     # options are:
-    #    call!(game, player)
-    #    raise_all_in!(game, player)
-    #    fold!(game, player)
+    #    call(game, player)
+    #    raise_all_in(game, player)
+    #    fold(game, player)
     if rand() < 0.5
         if rand() < 0.5 # Call
-            call!(game, player)
+            call(game, player)
         else # re-raise
-            raise_all_in!(game, player)
+            raise_all_in(game, player)
         end
     else
-        fold!(game, player)
+        fold(game, player)
     end
 end
-function TH.player_option!(game::Game, player::Player{MyBot}, ::CallFold)
+function TH.player_option(game::Game, player::Player{MyBot}, ::CallFold)
     # options are:
-    #    call!(game, player)
-    #    fold!(game, player)
+    #    call(game, player)
+    #    fold(game, player)
     if rand() < 0.5
-        call!(game, player)
+        call(game, player)
     else
-        fold!(game, player)
+        fold(game, player)
     end
 end
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -2,7 +2,7 @@
 
 ```@docs
 TexasHoldem
-TexasHoldem.raise_to!
+TexasHoldem.raise_to
 TexasHoldem.move_buttons!
 TexasHoldem.play!
 TexasHoldem.tournament!

--- a/src/game.jl
+++ b/src/game.jl
@@ -144,7 +144,7 @@ function act_generic!(game::Game, stage::AbstractGameStage)
         end
         all_in(player) && continue
         @cdebug logger "$(name(player))'s turn to act"
-        player_option!(game, player)
+        player_option(game, player)
         table.winners.declared && break
         end_preflop_actions(table, player, stage) && break
         if i > n_max_actions(table)

--- a/src/player_types.jl
+++ b/src/player_types.jl
@@ -20,7 +20,6 @@ mutable struct Player{S}
     seat_number::Int
     cards::Union{Nothing,Tuple{<:Card,<:Card}}
     bank_roll::Int
-    action_history::Vector
     action_required::Bool
     all_in::Bool
     round_bank_roll::Int # bank roll at the beginning of the round
@@ -38,7 +37,6 @@ function Base.show(io::IO, player::Player, include_type = true)
 end
 
 function Player(strategy, seat_number, cards = nothing; bank_roll = 200)
-    action_history = []
     action_required = true
     all_in = false
     round_bank_roll = bank_roll
@@ -54,7 +52,6 @@ function Player(strategy, seat_number, cards = nothing; bank_roll = 200)
         seat_number,
         cards,
         bank_roll,
-        action_history,
         action_required,
         all_in,
         round_bank_roll,
@@ -76,7 +73,6 @@ folded(player::Player) = player.folded
 zero_bank_roll(player::Player) = bank_roll(player) == 0
 still_playing(player::Player) = active(player) && !folded(player)
 not_playing(player::Player) = !still_playing(player)
-action_history(player::Player) = player.action_history
 checked(player::Player) = player.checked
 last_to_raise(player::Player) = player.last_to_raise
 all_in(player::Player) = player.all_in

--- a/test/game.jl
+++ b/test/game.jl
@@ -33,23 +33,23 @@ end
     players = TH.players_at_table(game)
     TH.deal!(game.table, TH.blinds(game.table))
     # Round 1
-    check!(game, players[1])
-    check!(game, players[2])
-    fold!(game, players[3])
+    TH.check!(game, players[1])
+    TH.check!(game, players[2])
+    TH.fold!(game, players[3])
 
     # Round 2
-    check!(game, players[1])
-    check!(game, players[2])
+    TH.check!(game, players[1])
+    TH.check!(game, players[2])
 
     # Round 3
-    raise_to!(game, players[1], 10)
+    TH.raise_to!(game, players[1], 10)
     @test TH.checked(players[1]) == false
-    call!(game, players[2])
+    TH.call!(game, players[2])
 
     # Round 4
-    raise_to!(game, players[1], 20)
+    TH.raise_to!(game, players[1], 20)
     @test TH.checked(players[1]) == false
-    fold!(game, players[2])
+    TH.fold!(game, players[2])
 
     # All-in cases
     players = ntuple(3) do i
@@ -59,15 +59,15 @@ end
     players = TH.players_at_table(game)
     TH.deal!(game.table, TH.blinds(game.table))
     # Round 1
-    check!(game, players[1])
-    check!(game, players[2])
-    fold!(game, players[3])
+    TH.check!(game, players[1])
+    TH.check!(game, players[2])
+    TH.fold!(game, players[3])
 
     # Round 2
-    raise_to!(game, players[1], players[1].bank_roll)
+    TH.raise_to!(game, players[1], players[1].bank_roll)
     @test TH.checked(players[1]) == false
-    call!(game, players[2])
+    TH.call!(game, players[2])
 
-    @test_throws AssertionError raise_to!(game, players[1], 10000) # raise exceeds bank roll!
+    @test_throws AssertionError TH.raise_to!(game, players[1], 10000) # raise exceeds bank roll!
 end
 

--- a/test/human_player_option.jl
+++ b/test/human_player_option.jl
@@ -41,20 +41,20 @@ end
     players = (Player(Human(), 1), Player(Bot5050(), 2))
     game = Game(players)
     simulate_keystrokes(:down, :down, :enter, 'd')
-    TH.player_option!(game, players[1], CheckRaiseFold())
+    TH.player_option(game, players[1], CheckRaiseFold())
     simulate_keystrokes(:down, :down, :enter, 'd')
-    TH.player_option!(game, players[1], CallRaiseFold())
+    TH.player_option(game, players[1], CallRaiseFold())
     simulate_keystrokes(:down, :down, :enter, 'd')
-    TH.player_option!(game, players[1], CallAllInFold())
+    TH.player_option(game, players[1], CallAllInFold())
     simulate_keystrokes(:down, :enter, 'd')
-    TH.player_option!(game, players[1], CallFold())
+    TH.player_option(game, players[1], CallFold())
 end
 
 @testset "Test check" begin
     players = (Player(Human(), 1), Player(Bot5050(), 2))
     game = Game(players)
     simulate_keystrokes(:enter, 'd')
-    TH.player_option!(game, players[1], CheckRaiseFold())
+    TH.player_option(game, players[1], CheckRaiseFold())
 end
 
 @testset "Test call" begin
@@ -63,22 +63,22 @@ end
     game = Game(players)
     game.table.current_raise_amt = 10
     simulate_keystrokes(:enter, 'd', 10)
-    TH.player_option!(game, players[1], CallRaiseFold())
-    @test last(TH.action_history(players[1])) == Call{Int}(10)
+    act = TH.player_option(game, players[1], CallRaiseFold())
+    @test act == TH.Call(10)
 
     players = (Player(Human(), 1), Player(Bot5050(), 2))
     game = Game(players)
     game.table.current_raise_amt = 10
     simulate_keystrokes(:enter, 'd', 10)
-    TH.player_option!(game, players[1], CallAllInFold())
-    @test last(TH.action_history(players[1])) == Call{Int}(10)
+    act = TH.player_option(game, players[1], CallAllInFold())
+    @test act == TH.Call(10)
 
     players = (Player(Human(), 1), Player(Bot5050(), 2))
     game = Game(players)
     game.table.current_raise_amt = 10
     simulate_keystrokes(:enter, 'd', 10)
-    TH.player_option!(game, players[1], CallFold())
-    @test last(TH.action_history(players[1])) == Call{Int}(10)
+    act = TH.player_option(game, players[1], CallFold())
+    @test act == TH.Call(10)
 end
 
 @testset "Test All-in raise" begin
@@ -87,8 +87,9 @@ end
     game = Game(players)
     game.table.current_raise_amt = 10
     simulate_keystrokes(:down, :enter, 'd')
-    TH.player_option!(game, players[1], CallAllInFold())
-    @test last(TH.action_history(players[1])) == Raise{Int}(200)
+    act = TH.player_option(game, players[1], CallAllInFold())
+    @test act.amt == 200
+    @test act == TH.AllIn(act.amt)
 end
 
 #=
@@ -126,7 +127,7 @@ TH.use_input_io() = true
     simulate_keystrokes(:down, :enter) # select Raise
     TRT.automated_test(file, [10]) do emuterm
         @testset "Human player options: CheckRaiseFold" begin
-            TH.player_option!(game, players[1], CheckRaiseFold(), emuterm)
+            TH.player_option(game, players[1], CheckRaiseFold(), emuterm)
         end
     end
 
@@ -138,7 +139,7 @@ TH.use_input_io() = true
     simulate_keystrokes(:down, :enter) # select Raise
     TRT.automated_test(file, [20]) do emuterm
         @testset "Human player options: CallRaiseFold" begin
-            TH.player_option!(game, players[1], CallRaiseFold(), emuterm)
+            TH.player_option(game, players[1], CallRaiseFold(), emuterm)
         end
     end
 end

--- a/test/perf.jl
+++ b/test/perf.jl
@@ -29,11 +29,12 @@ do_work!(game)
 Random.seed!(1234)
 game = Game(players();logger=TH.ByPassLogger())
 n_expected_failures = Dict()
-n_expected_failures[v"1.9.2"] = 3
-n_expected_failures[v"1.8.5"] = 14
+n_expected_failures[v"1.9.2"] = 0
+n_expected_failures[v"1.8.5"] = 11
 nef = get(n_expected_failures, VERSION, minimum(values(n_expected_failures)))
 @testset "Inference" begin
     n = @n_failures do_work!(game)
     @test n ≤ nef
+    n < nef && @show n
     @test_broken n < nef
 end

--- a/test/play.jl
+++ b/test/play.jl
@@ -32,35 +32,33 @@ end
 
 struct NoActionBot <: AbstractAI end
 
-TH.player_option!(game::Game, player::Player{NoActionBot}, ::AbstractGameStage, ::PlayerOptions) = nothing
+TH.player_option(game::Game, player::Player{NoActionBot}, ::AbstractGameStage, ::PlayerOptions) = nothing
 
 @testset "Game: Play (NoActionBot)" begin
     game = QuietGame((Player(BotCheckCall(), 1), Player(NoActionBot(), 2),))
-    @test_throws AssertionError("Must take exactly 1 action.") play!(game)
+    # @test_throws AssertionError("Must take exactly 1 action.") play!(game)
+    @test_throws TypeError(:typeassert, "", TH.Action, nothing) play!(game)
 end
 
 @testset "Non-valid option using BotCheckOnCallRaiseFold" begin
     game = QuietGame((Player(BotCheckCall(), 1), Player(BotCheckOnCallRaiseFold(), 2),))
-    @test_throws ErrorException("Cannot check. Available options: CallRaiseFold") play!(game)
+    @test_throws AssertionError("a.name in (:call, :raise, :all_in, :fold)") play!(game)
 end
 @testset "Non-valid option using BotCheckOnCallAllInFold" begin
     game = QuietGame((Player(BotCheckOnCallAllInFold(), 1), Player(BotRaiseAlmostAllIn(), 2)))
-    @test_throws ErrorException("Cannot check. Available options: CallAllInFold") play!(game)
+    @test_throws AssertionError("a.name in (:call, :all_in, :fold)") play!(game)
 end
 @testset "Non-valid option using BotCheckOnCallFold" begin
     game = QuietGame((Player(BotCheckOnCallFold(), 1), Player(BotRaiseAllIn(), 2)))
-    @test_throws ErrorException("Cannot check. Available options: CallFold") play!(game)
+    @test_throws AssertionError("a.name in (:call, :fold)") play!(game)
 end
 @testset "Non-valid option using BotCallOnCheckRaiseFold" begin
     game = QuietGame((Player(BotCheckCall(), 1), Player(BotCallOnCheckRaiseFold(), 2),))
-    # We catch this incorrect option error before it's completed,
-    # so we can't error in `validate_action`
-    # @test_throws ErrorException("Cannot call. Available options: CheckRaiseFold") play!(game)
-    @test_throws AssertionError("Cannot contribute \$0 to the pot!") play!(game)
+    @test_throws AssertionError("a.name in (:check, :raise, :all_in, :fold)") play!(game)
 end
 @testset "Non-valid option using BotRaiseOnCallFold" begin
     game = QuietGame((Player(BotRaiseOnCallFold(), 1), Player(BotRaiseAllIn(), 2)))
-    @test_throws AssertionError("Cannot raise 0.") play!(game)
+    @test_throws AssertionError("a.name in (:call, :fold)") play!(game)
 end
 
 @testset "Player limps all in" begin

--- a/test/tester_bots.jl
+++ b/test/tester_bots.jl
@@ -10,104 +10,104 @@ const AGS = AbstractGameStage
 ##### BotCheckFold
 struct BotCheckFold <: AbstractAI end
 
-TH.player_option!(game::Game, player::Player{BotCheckFold}, ::AGS, ::CheckRaiseFold) = check!(game, player)
-TH.player_option!(game::Game, player::Player{BotCheckFold}, ::AGS, ::CallRaiseFold) = fold!(game, player)
-TH.player_option!(game::Game, player::Player{BotCheckFold}, ::AGS, ::CallAllInFold) = fold!(game, player)
-TH.player_option!(game::Game, player::Player{BotCheckFold}, ::AGS, ::CallFold) = fold!(game, player)
+TH.player_option(game::Game, player::Player{BotCheckFold}, ::AGS, ::CheckRaiseFold) = check(game, player)
+TH.player_option(game::Game, player::Player{BotCheckFold}, ::AGS, ::CallRaiseFold) = fold(game, player)
+TH.player_option(game::Game, player::Player{BotCheckFold}, ::AGS, ::CallAllInFold) = fold(game, player)
+TH.player_option(game::Game, player::Player{BotCheckFold}, ::AGS, ::CallFold) = fold(game, player)
 
 ##### BotCheckCall
 struct BotCheckCall <: AbstractAI end
 
-TH.player_option!(game::Game, player::Player{BotCheckCall}, ::AGS, ::CheckRaiseFold) = check!(game, player)
-TH.player_option!(game::Game, player::Player{BotCheckCall}, ::AGS, ::CallRaiseFold) = call!(game, player)
-TH.player_option!(game::Game, player::Player{BotCheckCall}, ::AGS, ::CallAllInFold) = call!(game, player)
-TH.player_option!(game::Game, player::Player{BotCheckCall}, ::AGS, ::CallFold) = call!(game, player)
+TH.player_option(game::Game, player::Player{BotCheckCall}, ::AGS, ::CheckRaiseFold) = check(game, player)
+TH.player_option(game::Game, player::Player{BotCheckCall}, ::AGS, ::CallRaiseFold) = call(game, player)
+TH.player_option(game::Game, player::Player{BotCheckCall}, ::AGS, ::CallAllInFold) = call(game, player)
+TH.player_option(game::Game, player::Player{BotCheckCall}, ::AGS, ::CallFold) = call(game, player)
 
 ##### BotFlopRaise
 struct BotFlopRaise <: AbstractAI end
 # Call blind / check pre-flop, raise on flop
 
-TH.player_option!(game::Game, player::Player{BotFlopRaise}, ::AGS, ::CheckRaiseFold) = check!(game, player)
-TH.player_option!(game::Game, player::Player{BotFlopRaise}, ::AGS, ::CallRaiseFold) = call!(game, player)
-TH.player_option!(game::Game, player::Player{BotFlopRaise}, ::AGS, ::CallAllInFold) = call!(game, player)
-TH.player_option!(game::Game, player::Player{BotFlopRaise}, ::AGS, ::CallFold) = call!(game, player)
+TH.player_option(game::Game, player::Player{BotFlopRaise}, ::AGS, ::CheckRaiseFold) = check(game, player)
+TH.player_option(game::Game, player::Player{BotFlopRaise}, ::AGS, ::CallRaiseFold) = call(game, player)
+TH.player_option(game::Game, player::Player{BotFlopRaise}, ::AGS, ::CallAllInFold) = call(game, player)
+TH.player_option(game::Game, player::Player{BotFlopRaise}, ::AGS, ::CallFold) = call(game, player)
 
-TH.player_option!(game::Game, player::Player{BotFlopRaise}, ::Flop, ::CheckRaiseFold) = raise_to!(game, player, bank_roll(player)/2)
+TH.player_option(game::Game, player::Player{BotFlopRaise}, ::Flop, ::CheckRaiseFold) = raise_to(game, player, Int(bank_roll(player)/2))
 
 ##### BotRaiseAllIn
 struct BotRaiseAllIn <: AbstractAI end
 # Call blind / check pre-flop, raise on flop
 
-TH.player_option!(game::Game, player::Player{BotRaiseAllIn}, ::AGS, ::CheckRaiseFold) = raise_all_in!(game, player)
-TH.player_option!(game::Game, player::Player{BotRaiseAllIn}, ::AGS, ::CallRaiseFold) = raise_all_in!(game, player)
-TH.player_option!(game::Game, player::Player{BotRaiseAllIn}, ::AGS, ::CallAllInFold) = raise_all_in!(game, player)
+TH.player_option(game::Game, player::Player{BotRaiseAllIn}, ::AGS, ::CheckRaiseFold) = raise_all_in(game, player)
+TH.player_option(game::Game, player::Player{BotRaiseAllIn}, ::AGS, ::CallRaiseFold) = raise_all_in(game, player)
+TH.player_option(game::Game, player::Player{BotRaiseAllIn}, ::AGS, ::CallAllInFold) = raise_all_in(game, player)
 
 ##### BotRaiseAlmostAllIn
 struct BotRaiseAlmostAllIn <: AbstractAI end
 # Call blind / check pre-flop, raise on flop
 
-TH.player_option!(game::Game, player::Player{BotRaiseAlmostAllIn}, ::AGS, ::CheckRaiseFold) = raise_to!(game, player, 0.9*round_bank_roll(player))
-TH.player_option!(game::Game, player::Player{BotRaiseAlmostAllIn}, ::AGS, ::CallRaiseFold) = raise_to!(game, player, 0.9*round_bank_roll(player))
-TH.player_option!(game::Game, player::Player{BotRaiseAlmostAllIn}, ::AGS, ::CallAllInFold) = raise_to!(game, player, 0.9*round_bank_roll(player))
+TH.player_option(game::Game, player::Player{BotRaiseAlmostAllIn}, ::AGS, ::CheckRaiseFold) = raise_to(game, player, Int(0.9*round_bank_roll(player)))
+TH.player_option(game::Game, player::Player{BotRaiseAlmostAllIn}, ::AGS, ::CallRaiseFold) = raise_to(game, player, Int(0.9*round_bank_roll(player)))
+TH.player_option(game::Game, player::Player{BotRaiseAlmostAllIn}, ::AGS, ::CallAllInFold) = raise_to(game, player, Int(0.9*round_bank_roll(player)))
 
 ##### BotBetSB
 struct BotBetSB <: AbstractAI end
 
-TH.player_option!(game::Game, player::Player{BotBetSB}, ::AGS, ::CheckRaiseFold) = raise_to!(game, player, TH.blinds(game).small)
-TH.player_option!(game::Game, player::Player{BotBetSB}, ::PreFlop, ::CheckRaiseFold) = raise_to!(game, player, TH.blinds(game).small)
-TH.player_option!(game::Game, player::Player{BotBetSB}, ::AGS, ::CallRaiseFold) = call!(game, player)
-TH.player_option!(game::Game, player::Player{BotBetSB}, ::AGS, ::CallFold) = call!(game, player)
+TH.player_option(game::Game, player::Player{BotBetSB}, ::AGS, ::CheckRaiseFold) = raise_to(game, player, TH.blinds(game).small)
+TH.player_option(game::Game, player::Player{BotBetSB}, ::PreFlop, ::CheckRaiseFold) = raise_to(game, player, TH.blinds(game).small)
+TH.player_option(game::Game, player::Player{BotBetSB}, ::AGS, ::CallRaiseFold) = call(game, player)
+TH.player_option(game::Game, player::Player{BotBetSB}, ::AGS, ::CallFold) = call(game, player)
 
 ##### BotBetBB
 struct BotBetBB <: AbstractAI end
 
-TH.player_option!(game::Game, player::Player{BotBetBB}, ::PreFlop, ::CheckRaiseFold) = raise_to!(game, player, 2*TH.blinds(game).big)
-TH.player_option!(game::Game, player::Player{BotBetBB}, ::AGS, ::CheckRaiseFold) = raise_to!(game, player, TH.blinds(game).big)
-TH.player_option!(game::Game, player::Player{BotBetBB}, ::AGS, ::CallRaiseFold) = call!(game, player)
-TH.player_option!(game::Game, player::Player{BotBetBB}, ::AGS, ::CallFold) = call!(game, player)
+TH.player_option(game::Game, player::Player{BotBetBB}, ::PreFlop, ::CheckRaiseFold) = raise_to(game, player, 2*TH.blinds(game).big)
+TH.player_option(game::Game, player::Player{BotBetBB}, ::AGS, ::CheckRaiseFold) = raise_to(game, player, TH.blinds(game).big)
+TH.player_option(game::Game, player::Player{BotBetBB}, ::AGS, ::CallRaiseFold) = call(game, player)
+TH.player_option(game::Game, player::Player{BotBetBB}, ::AGS, ::CallFold) = call(game, player)
 
 ##### BotCheckOnCallRaiseFold
 struct BotCheckOnCallRaiseFold <: AbstractAI end
 
-TH.player_option!(game::Game, player::Player{BotCheckOnCallRaiseFold}, ::AGS, ::CallRaiseFold) = check!(game, player)
+TH.player_option(game::Game, player::Player{BotCheckOnCallRaiseFold}, ::AGS, ::CallRaiseFold) = check(game, player)
 
 ##### BotCheckOnCallAllInFold
 struct BotCheckOnCallAllInFold <: AbstractAI end
 
-TH.player_option!(game::Game, player::Player{BotCheckOnCallAllInFold}, ::AGS, ::CallAllInFold) = check!(game, player)
+TH.player_option(game::Game, player::Player{BotCheckOnCallAllInFold}, ::AGS, ::CallAllInFold) = check(game, player)
 
 ##### BotCheckOnCallFold
 struct BotCheckOnCallFold <: AbstractAI end
 
-TH.player_option!(game::Game, player::Player{BotCheckOnCallFold}, ::AGS, ::CallFold) = check!(game, player)
+TH.player_option(game::Game, player::Player{BotCheckOnCallFold}, ::AGS, ::CallFold) = check(game, player)
 
 ##### BotCallOnCheckRaiseFold
 struct BotCallOnCheckRaiseFold <: AbstractAI end
 
-TH.player_option!(game::Game, player::Player{BotCallOnCheckRaiseFold}, ::PreFlop, ::CallRaiseFold) = call!(game, player)
-TH.player_option!(game::Game, player::Player{BotCallOnCheckRaiseFold}, ::AGS, ::CheckRaiseFold) = call!(game, player)
+TH.player_option(game::Game, player::Player{BotCallOnCheckRaiseFold}, ::PreFlop, ::CallRaiseFold) = call(game, player)
+TH.player_option(game::Game, player::Player{BotCallOnCheckRaiseFold}, ::AGS, ::CheckRaiseFold) = call(game, player)
 
 ##### BotRaiseOnCallFold
 struct BotRaiseOnCallFold <: AbstractAI end
 
-TH.player_option!(game::Game, player::Player{BotRaiseOnCallFold}, ::AGS, ::CallFold) = raise_to!(game, player, bank_roll(player))
+TH.player_option(game::Game, player::Player{BotRaiseOnCallFold}, ::AGS, ::CallFold) = raise_to(game, player, bank_roll(player))
 
 ##### BotLimpAllIn
 struct BotLimpAllIn <: AbstractAI end
 
-TH.player_option!(game::Game, player::Player{BotLimpAllIn}, ::AGS, ::PlayerOptions) = call!(game, player)
+TH.player_option(game::Game, player::Player{BotLimpAllIn}, ::AGS, ::PlayerOptions) = call(game, player)
 
 ##### BotNActions
 struct BotNActions <: AbstractAI end
 
-function TH.player_option!(game::Game, player::Player{BotNActions}, ::AGS, ::CheckRaiseFold)
-    check!(game, player)
+function TH.player_option(game::Game, player::Player{BotNActions}, ::AGS, ::CheckRaiseFold)
     n_check_actions[1]+=1
+    check(game, player)
 end
 
-function TH.player_option!(game::Game, player::Player{BotNActions}, ::AGS, ::CallRaiseFold)
-    call!(game, player)
+function TH.player_option(game::Game, player::Player{BotNActions}, ::AGS, ::CallRaiseFold)
     n_call_actions[1]+=1
+    call(game, player)
 end
 
 ##### BotPreFlopRaise
@@ -116,8 +116,8 @@ struct BotPreFlopRaise{FT} <: AbstractAI
 end
 # Call blind / check pre-flop, raise on flop
 
-TH.player_option!(game::Game, player::Player{<:BotPreFlopRaise}, ::AGS, ::CheckRaiseFold) = check!(game, player)
-TH.player_option!(game::Game, player::Player{<:BotPreFlopRaise}, ::AGS, ::CallRaiseFold) = raise_to!(game, player, TH.strategy(player).amt)
-TH.player_option!(game::Game, player::Player{<:BotPreFlopRaise}, ::AGS, ::CallAllInFold) = call!(game, player)
-TH.player_option!(game::Game, player::Player{<:BotPreFlopRaise}, ::AGS, ::CallFold) = call!(game, player)
-TH.player_option!(game::Game, player::Player{<:BotPreFlopRaise}, ::PreFlop, ::CheckRaiseFold) = raise_to!(game, player, TH.strategy(player).amt)
+TH.player_option(game::Game, player::Player{<:BotPreFlopRaise}, ::AGS, ::CheckRaiseFold) = check(game, player)
+TH.player_option(game::Game, player::Player{<:BotPreFlopRaise}, ::AGS, ::CallRaiseFold) = raise_to(game, player, TH.strategy(player).amt)
+TH.player_option(game::Game, player::Player{<:BotPreFlopRaise}, ::AGS, ::CallAllInFold) = call(game, player)
+TH.player_option(game::Game, player::Player{<:BotPreFlopRaise}, ::AGS, ::CallFold) = call(game, player)
+TH.player_option(game::Game, player::Player{<:BotPreFlopRaise}, ::PreFlop, ::CheckRaiseFold) = raise_to(game, player, TH.strategy(player).amt)


### PR DESCRIPTION
This PR makes a few big changes:
 - We remove `action_history`, which was used to help test that the correct (and only 1) action was taken
 - To preserve these tests, `player_option` is now functional, and not mutating, so we can test the action directly
 - Subsequently, `check!` -> `check`, `call!` -> `call` etc., however, we did define versions of this for the convenience of testing (however, these are not meant to be user-facing):
```julia
call!(t, p) = update_given_valid_action!(t, p, call(t, p))
raise_to!(t, p, amt) = update_given_valid_action!(t, p, raise_to(t, p, amt))
fold!(t, p) = update_given_valid_action!(t, p, fold(t, p))
check!(t, p) = update_given_valid_action!(t, p, check(t, p))
```
This results in complete type stability on Julia 1.9 🎉