### PR TITLE
Do coverage on 1.7

### DIFF
--- a/.github/workflows/CodeCov.yml
+++ b/.github/workflows/CodeCov.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Julia
       uses: julia-actions/setup-julia@latest
       with:
-        version: 1.9
+        version: 1.7
 
     - name: Test with coverage
       env:


### PR DESCRIPTION
We skip a bunch of tests on later versions due to upstream breaking changes