### PR TITLE
Add capability to goto player option

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TexasHoldem"
 uuid = "6cef90fc-eb55-4a2a-97d0-7ecce2b738fe"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/src/TexasHoldem.jl
+++ b/src/TexasHoldem.jl
@@ -28,6 +28,7 @@ struct Flop <: AbstractRound end
 struct Turn <: AbstractRound end
 struct River <: AbstractRound end
 
+include("goto_player_option.jl")
 include("player_type.jl")
 include("players.jl")
 include("transactions.jl")

--- a/src/goto_player_option.jl
+++ b/src/goto_player_option.jl
@@ -1,0 +1,12 @@
+abstract type AbstractGamePoint end
+struct StartOfGame <: AbstractGamePoint end
+struct PlayerOption{P, R, A} <: AbstractGamePoint
+    player::P
+    round::R
+    action::A
+end
+
+struct StartFrom{GP}
+    game_point::GP
+end
+

--- a/src/player_options.jl
+++ b/src/player_options.jl
@@ -293,7 +293,7 @@ function player_option(game::Game, player::Player)
         action = player_option(game, player, CheckRaiseFold())::Action
         validate_action(action, CheckRaiseFold())
     end
-    update_given_valid_action!(table, player, action)
+    return action
 end
 
 # By default, forward to `player_option` with

--- a/test/goto_player_option.jl
+++ b/test/goto_player_option.jl
@@ -1,0 +1,62 @@
+using Test
+using PlayingCards
+using TexasHoldem
+import TexasHoldem
+const TH = TexasHoldem
+import Random
+Random.seed!(1234)
+
+QuietGame(args...; kwargs...) = Game(args...; kwargs..., logger=TH.ByPassLogger())
+
+include("tester_bots.jl")
+
+##### RiverDreamer
+mutable struct RiverDreamer <: AbstractStrategy
+    fixed::Bool
+end
+
+TH.player_option(game::Game, player::Player{RiverDreamer}, ::AGS, ::CheckRaiseFold) = Check()
+TH.player_option(game::Game, player::Player{RiverDreamer}, ::AGS, ::CallRaiseFold) = Call(game, player)
+TH.player_option(game::Game, player::Player{RiverDreamer}, ::AGS, ::CallAllInFold) = Call(game, player)
+TH.player_option(game::Game, player::Player{RiverDreamer}, ::AGS, ::CallFold) = Call(game, player)
+
+function TH.player_option(game::Game, player::Player{RiverDreamer}, round::River, option::CheckRaiseFold)
+    if player.strategy.fixed
+        Check()
+    else
+        player.strategy.fixed = true
+        vrr = TH.valid_raise_range(game.table, player)
+        raises = sort(map(x->rand(vrr), 1:10))
+        actions = (Check(), map(x->Raise(x), raises)..., Fold())
+        @show actions
+        rewards = map(actions) do action
+            rgame = TH.recreate_game(game, player)
+            sf = TH.StartFrom(TH.PlayerOption(player, round, action))
+            play!(rgame, sf)
+            pidx = findfirst(rgame.table.players) do p
+                TH.seat_number(p) == TH.seat_number(player)
+            end
+            rgame.table.players[pidx].game_profit
+        end
+        @show rewards
+        return Check()
+    end
+end
+function TH.player_option(game::Game, player::Player{RiverDreamer}, round::River, option::CallRaiseFold)
+    rgame = TH.recreate_game(game, player)
+    Call(game, player)
+end
+function TH.player_option(game::Game, player::Player{RiverDreamer}, round::River, option::CallAllInFold)
+    rgame = TH.recreate_game(game, player)
+    Call(game, player)
+end
+function TH.player_option(game::Game, player::Player{RiverDreamer}, round::River, option::CallFold)
+    rgame = TH.recreate_game(game, player)
+    Call(game, player)
+end
+
+@testset "Game: Play (Bot5050 vs RiverDreamer)" begin
+    fuzz_bots = ntuple(i->Player(Bot5050(), i), 3)
+    players = (fuzz_bots..., Player(RiverDreamer(false), length(fuzz_bots)+1))
+    play!(QuietGame(players))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,9 @@ end
 @safetestset "recreate" begin
     Δt = @elapsed include("recreate.jl"); @info "Completed tests for recreate in $Δt seconds"
 end
+@safetestset "goto player option" begin
+    Δt = @elapsed include("goto_player_option.jl"); @info "Completed tests for goto_player_option in $Δt seconds"
+end
 @safetestset "play" begin
     Δt = @elapsed include("play.jl"); @info "Completed tests for play in $Δt seconds"
 end


### PR DESCRIPTION
This is nearly finished, the only quark is that `initial_∑brs` is stateful inside `play!`, so recomputing it from a preset game ends up corrupting the initial bank rolls. I.e., this needs to be handled more carefully. Re-sampling the games from the river does show different rewards for different options against the Bot5050 🎉

Maybe we can bikeshed names a bit.

This is the last thing, AFAICT, needed to do search for training bots.