### PR TITLE
Bot5050 -> FuzzBot, add sane Bot5050

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,6 @@ format = Documenter.HTML(
 
 makedocs(
     sitename = "TexasHoldem.jl",
-    strict = true,
     format = format,
     checkdocs = :exports,
     clean = true,

--- a/docs/src/perf.md
+++ b/docs/src/perf.md
@@ -10,7 +10,7 @@ import Logging
 import Random
 Random.seed!(1234)
 
-players() = ntuple(i->(Player(Bot5050(), i)), 4)
+players() = ntuple(i->(Player(TH.FuzzBot(), i)), 4)
 
 function do_work!()
     play!(Game(players();logger=TH.ByPassLogger()))

--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -9,7 +9,7 @@ import Logging
 import Random
 Random.seed!(1234)
 
-players() = ntuple(i->(Player(Bot5050(), i)), 4)
+players() = ntuple(i->(Player(TH.FuzzBot(), i)), 4)
 
 # It's not easy to benchmark games without
 # also benchmarking the creation/allocation

--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -9,7 +9,7 @@ import Logging
 import Random
 Random.seed!(1234)
 
-players() = ntuple(i->(Player(Bot5050(), i)), 4)
+players() = ntuple(i->(Player(TH.FuzzBot(), i)), 4)
 
 function do_work!(games)
     for game in games

--- a/perf/jet.jl
+++ b/perf/jet.jl
@@ -6,7 +6,7 @@ const TH = TexasHoldem
 using TexasHoldem
 using BenchmarkTools
 
-players() = ntuple(i->(Player(Bot5050(), i)), 4)
+players() = ntuple(i->(Player(TH.FuzzBot(), i)), 4)
 
 function do_work!(game)
     play!(game)

--- a/src/player_options.jl
+++ b/src/player_options.jl
@@ -305,14 +305,35 @@ player_option(game::Game, player::Player, option) =
 ##### AbstractStrategy
 #####
 
-##### Bot5050
+##### FuzzBot
 
-function player_option(game::Game, player::Player{Bot5050}, ::CheckRaiseFold)
+function player_option(game::Game, player::Player{FuzzBot}, ::CheckRaiseFold)
     rand() < 0.5 && return Check()
     rand() < 0.5 && return Raise(rand(valid_raise_range(game.table, player)))
     # while we can check for free, this bot is used for fuzzing,
     # so we want to explore the most diverse set of possible cases.
     return Fold()
+end
+function player_option(game::Game, player::Player{FuzzBot}, ::CallRaiseFold)
+    rand() < 0.5 && return Call(game.table, player)
+    rand() < 0.5 && return Raise(rand(valid_raise_range(game.table, player))) # re-raise
+    return Fold()
+end
+function player_option(game::Game, player::Player{FuzzBot}, ::CallAllInFold)
+    rand() < 0.5 && return Call(game.table, player)
+    rand() < 0.5 && return AllIn(game.table, player) # re-raise
+    return Fold()
+end
+function player_option(game::Game, player::Player{FuzzBot}, ::CallFold)
+    rand() < 0.5 && return Call(game.table, player)
+    return Fold()
+end
+
+##### Bot5050
+
+function player_option(game::Game, player::Player{Bot5050}, ::CheckRaiseFold)
+    rand() < 0.5 && return Check()
+    return Raise(rand(valid_raise_range(game.table, player)))
 end
 function player_option(game::Game, player::Player{Bot5050}, ::CallRaiseFold)
     rand() < 0.5 && return Call(game.table, player)

--- a/src/player_type.jl
+++ b/src/player_type.jl
@@ -23,6 +23,19 @@ and not for simulating games.
 """
 struct Human <: AbstractStrategy end
 
+#=
+    FuzzBot
+
+`FuzzBot` is a stochastic strategy that
+chooses all of its actions based on a
+coin flip.
+
+This bot is used for fuzzing in the test
+suite and for quick-start game configurations
+for users.
+=#
+struct FuzzBot <: AbstractStrategy end
+
 """
     Bot5050
 
@@ -30,9 +43,8 @@ struct Human <: AbstractStrategy end
 chooses all of its actions based on a
 coin flip.
 
-This bot is used for fuzzing in the test
-suite and for quick-start game configurations
-for users.
+This bot is used for quick-start game
+configurations for users.
 """
 struct Bot5050 <: AbstractStrategy end
 

--- a/test/call_raise_validation.jl
+++ b/test/call_raise_validation.jl
@@ -49,56 +49,56 @@ end
 
 @testset "valid_raise_range" begin
     # Case 1
-    table = QuietGame((Player(Bot5050(), 1; bank_roll=1), Player(Bot5050(), 2));blinds = TH.Blinds(2,4)).table
+    table = QuietGame((Player(TH.FuzzBot(), 1; bank_roll=1), Player(TH.FuzzBot(), 2));blinds = TH.Blinds(2,4)).table
     players = TH.players_at_table(table)
     table.current_raise_amt = 0
     @test valid_raise_range_simple(table, players[1]) == (TH.valid_raise_range(table, players[1]), 1)
 
     # Case 2
-    table = QuietGame((Player(Bot5050(), 1), Player(Bot5050(), 2; bank_roll = 300))).table
+    table = QuietGame((Player(TH.FuzzBot(), 1), Player(TH.FuzzBot(), 2; bank_roll = 300))).table
     players = TH.players_at_table(table)
     table.current_raise_amt = 0
     @test valid_raise_range_simple(table, players[1]) == (TH.valid_raise_range(table, players[1]), 2)
 
     # Case 3
-    table = QuietGame((Player(Bot5050(), 1; bank_roll=2), Player(Bot5050(), 2; bank_roll = 1)); blinds=TH.Blinds(2,4)).table
+    table = QuietGame((Player(TH.FuzzBot(), 1; bank_roll=2), Player(TH.FuzzBot(), 2; bank_roll = 1)); blinds=TH.Blinds(2,4)).table
     players = TH.players_at_table(table)
     table.current_raise_amt = 0
     @test valid_raise_range_simple(table, players[1]) == (TH.valid_raise_range(table, players[1]), 3)
 
     # Case 4
-    table = QuietGame((Player(Bot5050(), 1), Player(Bot5050(), 2; bank_roll = 50))).table
+    table = QuietGame((Player(TH.FuzzBot(), 1), Player(TH.FuzzBot(), 2; bank_roll = 50))).table
     players = TH.players_at_table(table)
     table.current_raise_amt = 0
     @test valid_raise_range_simple(table, players[1]) == (TH.valid_raise_range(table, players[1]), 4)
 
     # Case 5
-    table = QuietGame((Player(Bot5050(), 1; bank_roll=1), Player(Bot5050(), 2))).table
+    table = QuietGame((Player(TH.FuzzBot(), 1; bank_roll=1), Player(TH.FuzzBot(), 2))).table
     players = TH.players_at_table(table)
     table.current_raise_amt = 1
     @test valid_raise_range_simple(table, players[1]) == (TH.valid_raise_range(table, players[1]), 5)
 
     # Case 6
-    table = QuietGame((Player(Bot5050(), 1), Player(Bot5050(), 2; bank_roll = 300))).table
+    table = QuietGame((Player(TH.FuzzBot(), 1), Player(TH.FuzzBot(), 2; bank_roll = 300))).table
     players = TH.players_at_table(table)
     table.current_raise_amt = 1
     @test valid_raise_range_simple(table, players[1]) == (TH.valid_raise_range(table, players[1]), 6)
 
     # Case 7
-    table = QuietGame((Player(Bot5050(), 1; bank_roll=2), Player(Bot5050(), 2; bank_roll = 1));blinds=TH.Blinds(2,4)).table
+    table = QuietGame((Player(TH.FuzzBot(), 1; bank_roll=2), Player(TH.FuzzBot(), 2; bank_roll = 1));blinds=TH.Blinds(2,4)).table
     players = TH.players_at_table(table)
     table.current_raise_amt = 1
     @test valid_raise_range_simple(table, players[1]) == (TH.valid_raise_range(table, players[1]), 7)
 
     # Case 8
-    table = QuietGame((Player(Bot5050(), 1), Player(Bot5050(), 2; bank_roll = 50))).table
+    table = QuietGame((Player(TH.FuzzBot(), 1), Player(TH.FuzzBot(), 2; bank_roll = 50))).table
     players = TH.players_at_table(table)
     table.current_raise_amt = 1
     @test valid_raise_range_simple(table, players[1]) == (TH.valid_raise_range(table, players[1]), 8)
 end
 
 @testset "is_valid_raise_amount" begin
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     table = QuietGame(players).table
     mra = TH.minimum_raise_amt(table)
     @assert mra == TH.blinds(table).small
@@ -111,7 +111,7 @@ end
     @test TH.is_valid_raise_amount(table, players[1], TH.blinds(table).big) == (true, "")
     @test TH.is_valid_raise_amount(table, players[1], TH.bank_roll(players[1])) == (true, "")
 
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     table = QuietGame(players).table
     table.initial_round_raise_amt = 20
     table.current_raise_amt = 20
@@ -119,28 +119,28 @@ end
     players[1].round_bank_roll = Chips(500) # oops
     @test TH.is_valid_raise_amount(table, players[1], 200) == (false, "Cannot contribute 0 to the pot.")
 
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     table = QuietGame(players).table
     table.initial_round_raise_amt = 10
     table.current_raise_amt = 10
     players[1].round_bank_roll = Chips(20)
     @test TH.is_valid_raise_amount(table, players[1], 10) == (false, "Only allowable raise is 20 (all-in)")
 
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     table = QuietGame(players).table
     table.initial_round_raise_amt = 10
     table.current_raise_amt = 10
     players[1].round_bank_roll = Chips(20)
     @test TH.is_valid_raise_amount(table, players[1], 20) == (true, "")
 
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     table = QuietGame(players).table
     table.initial_round_raise_amt = 5
     table.current_raise_amt = 20
     players[1].round_bank_roll = Chips(30)
     @test TH.is_valid_raise_amount(table, players[1], 25) == (true, "")
 
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     table = QuietGame(players).table
     table.initial_round_raise_amt = 5
     table.current_raise_amt = 20
@@ -149,45 +149,45 @@ end
 end
 
 @testset "call_amount" begin
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     table = QuietGame(players).table
     table.current_raise_amt = 20
     players[1].round_contribution = 10
     @test call_amount(table, players[1]) == 10
 
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     table = QuietGame(players).table
     table.current_raise_amt = 10
     players[1].round_contribution = 0
     @test call_amount(table, players[1]) == 10
 
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     table = QuietGame(players).table
     table.current_raise_amt = 0
     players[1].round_contribution = 10
     @test_throws AssertionError("Round contribution must be zero if current raise is zero.") call_amount(table, players[1])
 
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     table = QuietGame(players).table
     table.round = Flop()
     table.current_raise_amt = 10
     players[1].round_contribution = 10
     @test call_amount(table, players[1]) == 0
 
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     table = QuietGame(players).table
     table.round = Flop()
     table.current_raise_amt = 10
     players[1].round_contribution = 20
     @test_throws AssertionError("Call amount cannot be negative") call_amount(table, players[1])
 
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     table = QuietGame(players).table
     table.current_raise_amt = TH.blinds(table).big
     players[1].round_contribution = TH.blinds(table).big
     @test call_amount(table, players[1]) == 0 # action is back to big-blind pre-flop
 
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     table = QuietGame(players).table
     table.current_raise_amt = TH.blinds(table).big
     players[1].round_contribution = TH.blinds(table).big

--- a/test/fuzz_play.jl
+++ b/test/fuzz_play.jl
@@ -9,9 +9,9 @@ where `3788` was found from
 fuzz(;fun=tournament!,n_players=10,bank_roll=30,n_games=10000)
 
 players = (
-    Player(Bot5050(), 1; bank_roll=9),
-    Player(Bot5050(), 2; bank_roll=5),
-    Player(Bot5050(), 3; bank_roll=4),
+    Player(TH.FuzzBot(), 1; bank_roll=9),
+    Player(TH.FuzzBot(), 2; bank_roll=5),
+    Player(TH.FuzzBot(), 3; bank_roll=4),
 )
 fuzz_given_players_debug(;fun=play!, players, n_games=138)
 fuzz_debug(; fun = tournament!, n_players = 10, bank_roll = 30, n_games = 1310)
@@ -21,39 +21,39 @@ fuzz_debug(; fun = play!, n_players = 3, bank_roll = 200, n_games = 2373)
 =#
 include("fuzz_utils.jl")
 
-@testset "Game: play! (3 Bot5050's)" begin
+@testset "Game: play! (3 FuzzBot's)" begin
     @test isempty(fuzz(;fun=play!,n_players=3, bank_roll=200, n_games=100_000))
 end
 
-@testset "Game: play! (10 Bot5050's)" begin
+@testset "Game: play! (10 FuzzBot's)" begin
     @test isempty(fuzz(;fun=play!,n_players=10, bank_roll=200, n_games=10_000))
 end
 
-@testset "Game: play! (3 Bot5050's)" begin
+@testset "Game: play! (3 FuzzBot's)" begin
     players = (
-        Player(Bot5050(), 1; bank_roll=9),
-        Player(Bot5050(), 2; bank_roll=5),
-        Player(Bot5050(), 3; bank_roll=4),
+        Player(TH.FuzzBot(), 1; bank_roll=9),
+        Player(TH.FuzzBot(), 2; bank_roll=5),
+        Player(TH.FuzzBot(), 3; bank_roll=4),
     )
     @test isempty(fuzz_given_players(;fun=play!, players, n_games=10_000))
 end
 
-@testset "Game: tournament! (2 Bot5050's)" begin
+@testset "Game: tournament! (2 FuzzBot's)" begin
     @test isempty(fuzz(;fun=tournament!,n_players=2, bank_roll=6, n_games=10_000))
     @test isempty(fuzz(;fun=tournament!,n_players=2, bank_roll=30,n_games=100_000))
 end
 
-@testset "Game: tournament! (3 Bot5050's)" begin
+@testset "Game: tournament! (3 FuzzBot's)" begin
     @test isempty(fuzz(;fun=tournament!,n_players=3, bank_roll=6,  n_games=10_000))
     @test isempty(fuzz(;fun=tournament!,n_players=3, bank_roll=30, n_games=100_000))
 end
 
-@testset "Game: tournament! (10 Bot5050's)" begin
+@testset "Game: tournament! (10 FuzzBot's)" begin
     # https://github.com/charleskawczynski/TexasHoldem.jl/issues/151
     @test isempty(fuzz(;fun=tournament!,n_players=10,bank_roll=30,n_games=3788))
 end
 
-@testset "Game: tournament! (10 Bot5050's)" begin
+@testset "Game: tournament! (10 FuzzBot's)" begin
     # https://github.com/charleskawczynski/TexasHoldem.jl/issues/151
     @test isempty(fuzz(;fun=tournament!,n_players=10,bank_roll=30,n_games=3788))
 end
@@ -66,9 +66,9 @@ end
     br = 30
     rperm = Random.randperm(n_players)
     games1 = seeded_game(;fun=play!, n_games, players =
-            ntuple(i->Player(Bot5050(), i; bank_roll=br), n_players))
+            ntuple(i->Player(TH.FuzzBot(), i; bank_roll=br), n_players))
     games2 = seeded_game(;fun=play!, n_games, players =
-            ntuple(i->Player(Bot5050(), rperm[i]; bank_roll=br), n_players))
+            ntuple(i->Player(TH.FuzzBot(), rperm[i]; bank_roll=br), n_players))
 
     for (g1, g2) in zip(games1, games2)
         for (p1, p2) in zip(g1.table.players, g2.table.players)

--- a/test/fuzz_utils.jl
+++ b/test/fuzz_utils.jl
@@ -1,6 +1,7 @@
 using Test
 using PlayingCards
 using TexasHoldem
+const TH = TexasHoldem
 import Random
 import Logging
 
@@ -25,7 +26,7 @@ to enforce tests that work.
 =#
 function fuzz(;fun, n_players, n_games, bank_roll=200)
     Random.seed!(1234)
-    players = ntuple(i->Player(Bot5050(), i; bank_roll=bank_roll), n_players)
+    players = ntuple(i->Player(TH.FuzzBot(), i; bank_roll=bank_roll), n_players)
     return fuzz_given_players(;fun, n_games, players)
 end
 
@@ -57,7 +58,7 @@ swap the logger to debug level for the
 indices that fail.
 =#
 function fuzz_debug(;fun,n_players, n_games, bank_roll=200)
-    players = ntuple(i->Player(Bot5050(), i; bank_roll=bank_roll), n_players)
+    players = ntuple(i->Player(TH.FuzzBot(), i; bank_roll=bank_roll), n_players)
     fuzz_given_players_debug(;fun,n_games, players)
 end
 

--- a/test/game.jl
+++ b/test/game.jl
@@ -17,7 +17,7 @@ QuietGame(args...; kwargs...) = Game(args...; kwargs..., logger=TH.ByPassLogger(
 
 @testset "Game: show" begin
     players = ntuple(2) do i
-        Player(Bot5050(), i)
+        Player(TH.FuzzBot(), i)
     end
     game = QuietGame(players)
     sprint(show, game)
@@ -31,14 +31,14 @@ end
     # we use StatsBase.sample! for efficiency, but shuffle! is convenient
     shuffle!(deck)
     players = ntuple(3) do i
-        Player(Bot5050(), i, pop!(deck, Val(2)))
+        Player(TH.FuzzBot(), i, pop!(deck, Val(2)))
     end
     game = QuietGame(players;deck=deck,cards=pop!(deck, Val(5)))
 end
 
 @testset "Game: contrived game" begin
     players = ntuple(3) do i
-        Player(Bot5050(), i)
+        Player(TH.FuzzBot(), i)
     end
     game = QuietGame(players)
     players = TH.players_at_table(game)
@@ -64,7 +64,7 @@ end
 
     # All-in cases
     players = ntuple(3) do i
-        Player(Bot5050(), i)
+        Player(TH.FuzzBot(), i)
     end
     game = QuietGame(players)
     players = TH.players_at_table(game)

--- a/test/goto_player_option.jl
+++ b/test/goto_player_option.jl
@@ -56,8 +56,8 @@ function TH.player_option(game::Game, player::Player{RiverDreamer}, round::River
     Call(game, player)
 end
 
-@testset "Game: Play (Bot5050 vs RiverDreamer)" begin
-    fuzz_bots = ntuple(i->Player(Bot5050(), i), 3)
+@testset "Game: Play (FuzzBot vs RiverDreamer)" begin
+    fuzz_bots = ntuple(i->Player(TH.FuzzBot(), i), 3)
     players = (fuzz_bots..., Player(RiverDreamer(false), length(fuzz_bots)+1))
     play!(QuietGame(players))
 end

--- a/test/human_player_option.jl
+++ b/test/human_player_option.jl
@@ -38,7 +38,7 @@ else
 end
 
 @testset "Test fold" begin
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     game = Game(players)
     simulate_keystrokes(:down, :down, :enter, 'd')
     TH.player_option(game, players[1], CheckRaiseFold())
@@ -51,7 +51,7 @@ end
 end
 
 @testset "Test check" begin
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     game = Game(players)
     simulate_keystrokes(:enter, 'd')
     TH.player_option(game, players[1], CheckRaiseFold())
@@ -59,21 +59,21 @@ end
 
 @testset "Test call" begin
     # No initial round contribution
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     game = Game(players)
     game.table.current_raise_amt = 10
     simulate_keystrokes(:enter, 'd', 10)
     act = TH.player_option(game, players[1], CallRaiseFold())
     @test act == TH.Call(10)
 
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     game = Game(players)
     game.table.current_raise_amt = 10
     simulate_keystrokes(:enter, 'd', 10)
     act = TH.player_option(game, players[1], CallAllInFold())
     @test act == TH.Call(10)
 
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     game = Game(players)
     game.table.current_raise_amt = 10
     simulate_keystrokes(:enter, 'd', 10)
@@ -83,7 +83,7 @@ end
 
 @testset "Test All-in raise" begin
     # No initial round contribution
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     game = Game(players)
     game.table.current_raise_amt = 10
     simulate_keystrokes(:down, :enter, 'd')
@@ -109,7 +109,7 @@ TH.use_input_io() = true
     TRT = TerminalRegressionTests
     path = "terminal_test_output"
 
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     game = Game(players)
     table = game.table
     file = joinpath(path,"input_raise_amt.output")
@@ -119,7 +119,7 @@ TH.use_input_io() = true
         end
     end
 
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     game = Game(players)
     table = game.table
     table.current_raise_amt = 0
@@ -131,7 +131,7 @@ TH.use_input_io() = true
         end
     end
 
-    players = (Player(Human(), 1), Player(Bot5050(), 2))
+    players = (Player(Human(), 1), Player(TH.FuzzBot(), 2))
     game = Game(players)
     table = game.table
     table.current_raise_amt = 10

--- a/test/perf.jl
+++ b/test/perf.jl
@@ -15,7 +15,7 @@ macro n_failures(ex)
     )
 end
 
-players() = ntuple(i->(Player(Bot5050(), i)), 4)
+players() = ntuple(i->(Player(TH.FuzzBot(), i)), 4)
 
 function do_work!(game)
     play!(game)

--- a/test/play.jl
+++ b/test/play.jl
@@ -10,8 +10,8 @@ include("tester_bots.jl")
 QuietGame(args...; kwargs...) = Game(args...; kwargs..., logger=TH.ByPassLogger())
 
 @testset "Game: Play (invalid number of players)" begin
-    @test_throws AssertionError("Invalid number of players") QuietGame(ntuple(i->Player(Bot5050(), i), 1))
-    @test_throws AssertionError("Invalid number of players") QuietGame(ntuple(i->Player(Bot5050(), i), 11))
+    @test_throws AssertionError("Invalid number of players") QuietGame(ntuple(i->Player(TH.FuzzBot(), i), 1))
+    @test_throws AssertionError("Invalid number of players") QuietGame(ntuple(i->Player(TH.FuzzBot(), i), 11))
 end
 
 @testset "Game: Play (BotCheckCall)" begin

--- a/test/players.jl
+++ b/test/players.jl
@@ -6,10 +6,10 @@ const TH = TexasHoldem
 @testset "Players" begin
     players = (
         Player(Human(), 1),
-        Player(Bot5050(), 2),
+        Player(TH.FuzzBot(), 2),
     )
     @test TH.name(players[1]) == "Human[1]"
-    @test TH.name(players[2]) == "Bot5050[2]"
+    @test TH.name(players[2]) == "FuzzBot[2]"
     @test TH.cards(players[1]) == players[1].cards
     @test TH.cards(players[2]) == players[2].cards
 end

--- a/test/reproducibility.jl
+++ b/test/reproducibility.jl
@@ -1,10 +1,11 @@
 using Test
 using TexasHoldem
+const TH = TexasHoldem
 import Random
 
 function seeded_game(; fun, n_players, n_games, bank_roll=200)
     Random.seed!(1234)
-    players = ntuple(i->Player(Bot5050(), i; bank_roll=bank_roll), n_players)
+    players = ntuple(i->Player(TH.FuzzBot(), i; bank_roll=bank_roll), n_players)
     games = map(x->Game(deepcopy(players);logger=TexasHoldem.ByPassLogger()), 1:n_games)
     for n in 1:length(games)
         game = games[n]

--- a/test/table.jl
+++ b/test/table.jl
@@ -8,7 +8,7 @@ using TexasHoldem: seat_number
 const TH = TexasHoldem
 
 @testset "Table: constructors / observed cards" begin
-    players = ntuple(i-> Player(Bot5050(), i), 2)
+    players = ntuple(i-> Player(TH.FuzzBot(), i), 2)
     deck = PlayingCards.MaskedDeck()
     # we use StatsBase.sample! for efficiency, but shuffle! is convenient
     shuffle!(deck)
@@ -34,7 +34,7 @@ end
 
 @testset "Table: Move button" begin
     # All players playing
-    players = ntuple(i-> Player(Bot5050(), i), 3)
+    players = ntuple(i-> Player(TH.FuzzBot(), i), 3)
     table = Table(players, logger=TH.ByPassLogger())
     @test TH.buttons(table.buttons) == (1, 2, 3, 1)
     move_buttons!(table)
@@ -46,9 +46,9 @@ end
 
     # Some players not playing
     players = (
-        Player(Bot5050(), 1),
-        Player(Bot5050(), 2; bank_roll=0),
-        Player(Bot5050(), 3),
+        Player(TH.FuzzBot(), 1),
+        Player(TH.FuzzBot(), 2; bank_roll=0),
+        Player(TH.FuzzBot(), 3),
     )
     table = Table(players, logger=TH.ByPassLogger())
     @test TH.buttons(table.buttons) == (1, 3, 1, 3)
@@ -61,9 +61,9 @@ end
 
     # Some players not playing
     players = (
-        Player(Bot5050(), 1),
-        Player(Bot5050(), 2; bank_roll=0),
-        Player(Bot5050(), 3),
+        Player(TH.FuzzBot(), 1),
+        Player(TH.FuzzBot(), 2; bank_roll=0),
+        Player(TH.FuzzBot(), 3),
     )
     table = Table(players; dealer_pidx=2, logger=TH.ByPassLogger())
     @test TH.buttons(table.buttons) == (3, 1, 3, 1)
@@ -91,14 +91,14 @@ end
     @test TH.default_dealer_pidx() == 1
 
     # dealer_pidx = 1
-    players = ntuple(i-> Player(Bot5050(), i), 5)
+    players = ntuple(i-> Player(TH.FuzzBot(), i), 5)
     table = Table(players, logger=TH.ByPassLogger())
     TH.deal!(table, TH.blinds(table))
     ind = collect(TH.circle(table, Dealer(), length(players)))
     @test ind == [1, 2, 3, 4, 5]
 
     dealer_pidx = 2
-    players = ntuple(i-> Player(Bot5050(), i), 5)
+    players = ntuple(i-> Player(TH.FuzzBot(), i), 5)
     table = Table(players; dealer_pidx = 2, logger=TH.ByPassLogger())
     TH.deal!(table, TH.blinds(table))
     ind = collect(TH.circle(table, Dealer(), length(players)))
@@ -107,14 +107,14 @@ end
 
 @testset "Table: SmallBlind iterator" begin
     # dealer_pidx = 1
-    players = ntuple(i-> Player(Bot5050(), i), 5)
+    players = ntuple(i-> Player(TH.FuzzBot(), i), 5)
     table = Table(players, logger=TH.ByPassLogger())
     TH.deal!(table, TH.blinds(table))
     ind = collect(TH.circle(table, SmallBlind(), length(players)))
     @test ind == [2, 3, 4, 5, 1]
 
     # dealer_pidx = 2
-    players = ntuple(i-> Player(Bot5050(), i), 5)
+    players = ntuple(i-> Player(TH.FuzzBot(), i), 5)
     table = Table(players; dealer_pidx = 2, logger=TH.ByPassLogger())
     TH.deal!(table, TH.blinds(table))
     ind = collect(TH.circle(table, SmallBlind(), length(players)))
@@ -123,14 +123,14 @@ end
 
 @testset "Table: BigBlind iterator" begin
     # dealer_pidx = 1
-    players = ntuple(i-> Player(Bot5050(), i), 5)
+    players = ntuple(i-> Player(TH.FuzzBot(), i), 5)
     table = Table(players, logger=TH.ByPassLogger())
     TH.deal!(table, TH.blinds(table))
     ind = collect(TH.circle(table, BigBlind(), length(players)))
     @test ind == [3, 4, 5, 1, 2]
 
     # dealer_pidx = 2
-    players = ntuple(i-> Player(Bot5050(), i), 5)
+    players = ntuple(i-> Player(TH.FuzzBot(), i), 5)
     table = Table(players; dealer_pidx = 2, logger=TH.ByPassLogger())
     TH.deal!(table, TH.blinds(table))
     ind = collect(TH.circle(table, BigBlind(), length(players)))
@@ -139,14 +139,14 @@ end
 
 @testset "Table: FirstToAct iterator" begin
     # dealer_pidx = 1
-    players = ntuple(i-> Player(Bot5050(), i), 5)
+    players = ntuple(i-> Player(TH.FuzzBot(), i), 5)
     table = Table(players, logger=TH.ByPassLogger())
     TH.deal!(table, TH.blinds(table))
     ind = collect(TH.circle(table, FirstToAct(), length(players)))
     @test ind == [4, 5, 1, 2, 3]
 
     # dealer_pidx = 2
-    players = ntuple(i-> Player(Bot5050(), i), 5)
+    players = ntuple(i-> Player(TH.FuzzBot(), i), 5)
     table = Table(players; dealer_pidx = 2, logger=TH.ByPassLogger())
     TH.deal!(table, TH.blinds(table))
     ind = collect(TH.circle(table, FirstToAct(), length(players)))

--- a/test/transactions.jl
+++ b/test/transactions.jl
@@ -1,7 +1,7 @@
 using Test
 using PlayingCards
 using TexasHoldem
-using TexasHoldem: Player, Bot5050, TransactionManager, dealer_pidx, Table
+using TexasHoldem: Player, FuzzBot, TransactionManager, dealer_pidx, Table
 const TH = TexasHoldem
 all_zero(side_pots) = all(x-> all(y->y==0, x), side_pots)
 
@@ -20,9 +20,9 @@ check!(t, p) = TH.update_given_valid_action!(t, p, Check())
     table_cards = (A♢, K♢, Q♢, 2♠, 3♠)
     logger = TH.InfoLogger()
     players = (
-        Player(Bot5050(), 1, (A♠, A♣); bank_roll = 1*100),
-        Player(Bot5050(), 2, (K♠, K♣); bank_roll = 2*100),
-        Player(Bot5050(), 3, (Q♠, Q♣); bank_roll = 3*100),
+        Player(TH.FuzzBot(), 1, (A♠, A♣); bank_roll = 1*100),
+        Player(TH.FuzzBot(), 2, (K♠, K♣); bank_roll = 2*100),
+        Player(TH.FuzzBot(), 3, (Q♠, Q♣); bank_roll = 3*100),
     )
     tm = TH.TransactionManager(players, logger)
     table = Table(players;cards=table_cards,transactions=tm, logger=TH.ByPassLogger())
@@ -44,9 +44,9 @@ end
     table_cards = (A♢, K♢, Q♢, 2♠, 3♠)
     logger = TH.InfoLogger()
     players = (
-        Player(Bot5050(), 1, (A♠, A♣); bank_roll = 3*100),
-        Player(Bot5050(), 2, (K♠, K♣); bank_roll = 2*100),
-        Player(Bot5050(), 3, (Q♠, Q♣); bank_roll = 1*100),
+        Player(TH.FuzzBot(), 1, (A♠, A♣); bank_roll = 3*100),
+        Player(TH.FuzzBot(), 2, (K♠, K♣); bank_roll = 2*100),
+        Player(TH.FuzzBot(), 3, (Q♠, Q♣); bank_roll = 1*100),
     )
     tm = TH.TransactionManager(players, logger)
     table = Table(players;cards=table_cards,transactions=tm, logger=TH.ByPassLogger())
@@ -68,9 +68,9 @@ end
     table_cards = (A♢, K♢, Q♢, 2♠, 3♠)
     logger = TH.InfoLogger()
     players = (
-        Player(Bot5050(), 1, (A♠, A♣); bank_roll = 1*100),
-        Player(Bot5050(), 2, (K♠, K♣); bank_roll = 2*100),
-        Player(Bot5050(), 3, (Q♠, Q♣); bank_roll = 3*100),
+        Player(TH.FuzzBot(), 1, (A♠, A♣); bank_roll = 1*100),
+        Player(TH.FuzzBot(), 2, (K♠, K♣); bank_roll = 2*100),
+        Player(TH.FuzzBot(), 3, (Q♠, Q♣); bank_roll = 3*100),
     )
     tm = TH.TransactionManager(players, logger)
     table = Table(players;cards=table_cards,transactions=tm, logger=TH.ByPassLogger())
@@ -101,9 +101,9 @@ end
     table_cards = (A♢, K♢, Q♢, 2♠, 3♠)
     logger = TH.InfoLogger()
     players = (
-        Player(Bot5050(), 1, (A♠, A♣); bank_roll = 3*100),
-        Player(Bot5050(), 2, (K♠, K♣); bank_roll = 2*100),
-        Player(Bot5050(), 3, (Q♠, Q♣); bank_roll = 1*100),
+        Player(TH.FuzzBot(), 1, (A♠, A♣); bank_roll = 3*100),
+        Player(TH.FuzzBot(), 2, (K♠, K♣); bank_roll = 2*100),
+        Player(TH.FuzzBot(), 3, (Q♠, Q♣); bank_roll = 1*100),
     )
     tm = TH.TransactionManager(players, logger)
     table = Table(players;cards=table_cards,transactions=tm, logger=TH.ByPassLogger())
@@ -134,12 +134,12 @@ end
     table_cards = (T♢, Q♢, A♠, 8♠, 9♠)
     logger = TH.InfoLogger()
     players = (
-        Player(Bot5050(), 1, (4♠, 5♣); bank_roll = 1*100), # bust
-        Player(Bot5050(), 2, (K♠, K♣); bank_roll = 2*100), # win, split with player 3
-        Player(Bot5050(), 3, (K♡,K♢); bank_roll = 3*100), # win, split with player 2
-        Player(Bot5050(), 4, (2♡, 3♢); bank_roll = 4*100), # bust
-        Player(Bot5050(), 5, (7♠, 7♣); bank_roll = 5*100), # 2nd to players 2 and 3, win remaining pot
-        Player(Bot5050(), 6, (2♠, 3♣); bank_roll = 6*100), # lose, but not bust
+        Player(TH.FuzzBot(), 1, (4♠, 5♣); bank_roll = 1*100), # bust
+        Player(TH.FuzzBot(), 2, (K♠, K♣); bank_roll = 2*100), # win, split with player 3
+        Player(TH.FuzzBot(), 3, (K♡,K♢); bank_roll = 3*100), # win, split with player 2
+        Player(TH.FuzzBot(), 4, (2♡, 3♢); bank_roll = 4*100), # bust
+        Player(TH.FuzzBot(), 5, (7♠, 7♣); bank_roll = 5*100), # 2nd to players 2 and 3, win remaining pot
+        Player(TH.FuzzBot(), 6, (2♠, 3♣); bank_roll = 6*100), # lose, but not bust
     )
     tm = TH.TransactionManager(players, logger)
     table = Table(players;cards=table_cards,transactions=tm, logger=TH.ByPassLogger())
@@ -199,12 +199,12 @@ end
     table_cards = (T♢, Q♢, A♠, 8♠, 9♠)
     logger = TH.InfoLogger()
     players = (
-        Player(Bot5050(), 1, (4♠, 5♣); bank_roll = 1*7), # bust
-        Player(Bot5050(), 2, (K♠, K♣); bank_roll = 2*7), # win, split with player 3
-        Player(Bot5050(), 3, (K♡,K♢); bank_roll = 3*7), # win, split with player 2
-        Player(Bot5050(), 4, (2♡, 3♢); bank_roll = 4*7), # bust
-        Player(Bot5050(), 5, (7♠, 7♣); bank_roll = 5*7), # 2nd to players 2 and 3, win remaining pot
-        Player(Bot5050(), 6, (2♠, 3♣); bank_roll = 6*7), # lose, but not bust
+        Player(TH.FuzzBot(), 1, (4♠, 5♣); bank_roll = 1*7), # bust
+        Player(TH.FuzzBot(), 2, (K♠, K♣); bank_roll = 2*7), # win, split with player 3
+        Player(TH.FuzzBot(), 3, (K♡,K♢); bank_roll = 3*7), # win, split with player 2
+        Player(TH.FuzzBot(), 4, (2♡, 3♢); bank_roll = 4*7), # bust
+        Player(TH.FuzzBot(), 5, (7♠, 7♣); bank_roll = 5*7), # 2nd to players 2 and 3, win remaining pot
+        Player(TH.FuzzBot(), 6, (2♠, 3♣); bank_roll = 6*7), # lose, but not bust
     )
     tm = TH.TransactionManager(players, logger)
     table = Table(players;cards=table_cards,transactions=tm, logger=TH.ByPassLogger())
@@ -264,12 +264,12 @@ end
     table_cards = (T♢, Q♢, A♠, 8♠, 9♠)
     logger = TH.InfoLogger()
     players = (
-        Player(Bot5050(), 1, (4♠, 5♣); bank_roll = 1*100), # bust
-        Player(Bot5050(), 2, (K♠, K♣); bank_roll = 2*100), # win, split with player 3
-        Player(Bot5050(), 3, (K♡,K♢); bank_roll = 3*100), # win, split with player 2
-        Player(Bot5050(), 4, (2♡, 3♢); bank_roll = 4*100), # bust
-        Player(Bot5050(), 5, (7♠, 7♣); bank_roll = 5*100), # 2nd to players 2 and 3, win remaining pot
-        Player(Bot5050(), 6, (2♠, 3♣); bank_roll = 6*100), # lose, but not bust
+        Player(TH.FuzzBot(), 1, (4♠, 5♣); bank_roll = 1*100), # bust
+        Player(TH.FuzzBot(), 2, (K♠, K♣); bank_roll = 2*100), # win, split with player 3
+        Player(TH.FuzzBot(), 3, (K♡,K♢); bank_roll = 3*100), # win, split with player 2
+        Player(TH.FuzzBot(), 4, (2♡, 3♢); bank_roll = 4*100), # bust
+        Player(TH.FuzzBot(), 5, (7♠, 7♣); bank_roll = 5*100), # 2nd to players 2 and 3, win remaining pot
+        Player(TH.FuzzBot(), 6, (2♠, 3♣); bank_roll = 6*100), # lose, but not bust
     )
     tm = TH.TransactionManager(players, logger)
     table = Table(players;cards=table_cards,transactions=tm, logger=TH.ByPassLogger())
@@ -310,12 +310,12 @@ end
     table_cards = (T♢, Q♢, A♠, 8♠, 9♠)
     logger = TH.InfoLogger()
     players = (
-        Player(Bot5050(), 1, (2♠, 3♣); bank_roll = 6*100), # lose, but not bust
-        Player(Bot5050(), 2, (7♠, 7♣); bank_roll = 5*100), # 2nd to players 2 and 3, win remaining pot
-        Player(Bot5050(), 3, (2♡, 3♢); bank_roll = 4*100), # bust
-        Player(Bot5050(), 4, (K♡,K♢); bank_roll = 3*100), # win, split with player 2
-        Player(Bot5050(), 5, (K♠, K♣); bank_roll = 2*100), # win, split with player 3
-        Player(Bot5050(), 6, (4♠, 5♣); bank_roll = 1*100), # bust
+        Player(TH.FuzzBot(), 1, (2♠, 3♣); bank_roll = 6*100), # lose, but not bust
+        Player(TH.FuzzBot(), 2, (7♠, 7♣); bank_roll = 5*100), # 2nd to players 2 and 3, win remaining pot
+        Player(TH.FuzzBot(), 3, (2♡, 3♢); bank_roll = 4*100), # bust
+        Player(TH.FuzzBot(), 4, (K♡,K♢); bank_roll = 3*100), # win, split with player 2
+        Player(TH.FuzzBot(), 5, (K♠, K♣); bank_roll = 2*100), # win, split with player 3
+        Player(TH.FuzzBot(), 6, (4♠, 5♣); bank_roll = 1*100), # bust
     )
     tm = TH.TransactionManager(players, logger)
     table = Table(players;cards=table_cards,transactions=tm, logger=TH.ByPassLogger())
@@ -357,8 +357,8 @@ end
     logger = TH.InfoLogger()
     players = (
         Player(BotPreFlopRaise(5), 1, (2♠, 3♣); bank_roll = 9),
-        Player(Bot5050(), 2, (7♠, 7♣); bank_roll = 5),
-        Player(Bot5050(), 3, (2♡, 3♢); bank_roll = 4),
+        Player(TH.FuzzBot(), 2, (7♠, 7♣); bank_roll = 5),
+        Player(TH.FuzzBot(), 3, (2♡, 3♢); bank_roll = 4),
     )
     tm = TH.TransactionManager(players, logger)
     table = Table(players;cards=table_cards,transactions=tm, logger=TH.ByPassLogger())


### PR DESCRIPTION
This PR renames `Bot5050` to `FuzzBot`, and adds `Bot5050` which is the same before but it doesn't fold when it can check. The FuzzBot is still used in the tests, since it's technically a valid action.