### PR TITLE
Make player options Symbol-backed

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,36 +36,33 @@ tournament!(configure_game()) # play until 1 player remains
 
 # Creating your own bot
 
-Four methods (variants of `player_option`) need to be defined to create and play your own bot:
+Overload `player_option` with your own bot and play against it:
 
 ```julia
 using TexasHoldem
+using TexasHoldem: Options
 import TexasHoldem: player_option
 
 struct MyBot <: AbstractStrategy end
 
-function player_option(game::Game, player::Player{MyBot}, ::CheckRaiseFold)
-    # options:
-    rand() < 0.5 && return Raise(rand(valid_raise_range(game.table, player)))
-    return Check()
-    # return Fold() # we can fold, but we can check for free
-end
-function player_option(game::Game, player::Player{MyBot}, ::CallRaiseFold)
-    # options:
-    rand() < 0.5 && return Call(game.table, player)
-    rand() < 0.5 && return Raise(rand(valid_raise_range(game.table, player)))
-    return Fold()
-end
-function player_option(game::Game, player::Player{MyBot}, ::CallAllInFold)
-    # options:
-    rand() < 0.5 && return Call(game.table, player)
-    rand() < 0.5 && return AllIn(game.table, player)
-    return Fold()
-end
-function player_option(game::Game, player::Player{MyBot}, ::CallFold)
-    # options:
-    rand() < 0.5 && return Call()
-    return Fold()
+function player_option(game::Game, player::Player{MyBot}, options::Options)
+    if options.name == :CheckRaiseFold
+        rand() < 0.5 && return Raise(rand(valid_raise_range(game.table, player)))
+        return Check()
+        # return Fold() # we can fold, but we can check for free
+    elseif options.name == :CallRaiseFold
+        rand() < 0.5 && return Call(game.table, player)
+        rand() < 0.5 && return Raise(rand(valid_raise_range(game.table, player)))
+        return Fold()
+    elseif options.name == :CallAllInFold
+        rand() < 0.5 && return Call(game.table, player)
+        rand() < 0.5 && return AllIn(game.table, player)
+        return Fold()
+    else
+        @assert options.name == :CallFold
+        rand() < 0.5 && return Call()
+        return Fold()
+    end
 end
 
 # Heads-up against MyBot!

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -44,7 +44,8 @@ valid_raise_range
 ## Player options
 
 ```@docs
-TexasHoldem.AbstractPlayerOptions
+TexasHoldem.Options
+TexasHoldem.get_options
 TexasHoldem.CheckRaiseFold
 TexasHoldem.CallRaiseFold
 TexasHoldem.CallAllInFold

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -6,24 +6,25 @@ Once you've finished [Installation](@ref), you can start playing games with:
 using TexasHoldem
 import TexasHoldem: player_option
 struct RandomBot <: AbstractStrategy end
-function player_option(game::Game, player::Player{RandomBot}, ::CheckRaiseFold)
-    rand() < 0.5 && return Raise(rand(valid_raise_range(game.table, player)))
-    return Check()
+function player_option(game::Game, player::Player{RandomBot}, options)
+    if options.name == :CheckRaiseFold
+        rand() < 0.5 && return Raise(rand(valid_raise_range(game.table, player)))
+        return Check()
+    elseif options.name == :CallRaiseFold
+        rand() < 0.5 && return Call(game.table, player)
+        rand() < 0.5 && return Raise(rand(valid_raise_range(game.table, player)))
+        return Fold()
+    elseif options.name == :CallAllInFold
+        rand() < 0.5 && return Call(game.table, player)
+        rand() < 0.5 && return AllIn(game.table, player)
+        return Fold()
+    elseif options.name == :CallFold
+        rand() < 0.5 && return Call(game.table, player)
+        return Fold()
+    else; error("Uncaught case")
+    end
 end
-function player_option(game::Game, player::Player{RandomBot}, ::CallRaiseFold)
-    rand() < 0.5 && return Call(game.table, player)
-    rand() < 0.5 && return Raise(rand(valid_raise_range(game.table, player)))
-    return Fold()
-end
-function player_option(game::Game, player::Player{RandomBot}, ::CallAllInFold)
-    rand() < 0.5 && return Call(game.table, player)
-    rand() < 0.5 && return AllIn(game.table, player)
-    return Fold()
-end
-function player_option(game::Game, player::Player{RandomBot}, ::CallFold)
-    rand() < 0.5 && return Call(game.table, player)
-    return Fold()
-end
+
 # Play against some bots!
 players = (Player(Human(), 1), ntuple(i->Player(RandomBot(), i+1), 4)...)
 tournament!(Game(players))

--- a/src/terminal/human_player_options.jl
+++ b/src/terminal/human_player_options.jl
@@ -2,57 +2,52 @@
 ##### Human player options (ask via prompts)
 #####
 
-function player_option(game::Game, player::Player{Human}, ::CheckRaiseFold, ioin::IO=stdin)
+function player_option(game::Game, player::Player{Human}, options::Options, ioin::IO=stdin)
     table = game.table
     update_gui(stdout, table, player)
-    vrr = valid_raise_range(table, player)
-    options = ["Check", "Raise [$(first(vrr)), $(last(vrr))]", "Fold"]
-    menu = RadioMenu(options, pagesize=4)
-    choice = request("$(name(player))'s turn to act:", menu)
-    choice == -1 && error("Uncaught case")
-    choice == 1 && return Check()
-    choice == 2 && return Raise(input_raise_amt(table, player, ioin))
-    choice == 3 && return Fold()
-end
-function player_option(game::Game, player::Player{Human}, ::CallRaiseFold, ioin::IO=stdin)
-    table = game.table
-    update_gui(stdout, table, player)
-    vrr = valid_raise_range(table, player)
-    call_amt = call_amount(table, player)
-    blind_str = is_blind_call(table, player) ? " (blind)" : ""
-    options = ["Call $(call_amt)$blind_str", "Raise [$(first(vrr)), $(last(vrr))]", "Fold"]
-    menu = RadioMenu(options, pagesize=4)
-    choice = request("$(name(player))'s turn to act:", menu)
-    choice == -1 && error("Uncaught case")
-    choice == 1 && return Call(table, player)
-    choice == 2 && return Raise(input_raise_amt(table, player, ioin))
-    choice == 3 && return Fold()
-end
-function player_option(game::Game, player::Player{Human}, ::CallAllInFold, ioin::IO=stdin)
-    table = game.table
-    update_gui(stdout, table, player)
-    call_amt = call_amount(table, player)
-    all_in_amt = round_bank_roll(player)
-    blind_str = is_blind_call(table, player) ? " (blind)" : ""
-    options = ["Call $(call_amt)$blind_str", "Raise all-in ($(all_in_amt))", "Fold"]
-    menu = RadioMenu(options, pagesize=4)
-    choice = request("$(name(player))'s turn to act:", menu)
-    choice == -1 && error("Uncaught case")
-    choice == 1 && return Call(table, player)
-    choice == 2 && return AllIn(table, player)
-    choice == 3 && return Fold()
-end
-function player_option(game::Game, player::Player{Human}, ::CallFold)
-    table = game.table
-    update_gui(stdout, table, player)
-    call_amt = call_amount(table, player)
-    blind_str = is_blind_call(table, player) ? " (blind)" : ""
-    options = ["Call $(call_amt)$blind_str", "Fold"]
-    menu = RadioMenu(options, pagesize=4)
-    choice = request("$(name(player))'s turn to act:", menu)
-    choice == -1 && error("Uncaught case")
-    choice == 1 && return Call(table, player)
-    choice == 2 && return Fold()
+    if options.name == :CheckRaiseFold
+        vrr = valid_raise_range(table, player)
+        moptions = ["Check", "Raise [$(first(vrr)), $(last(vrr))]", "Fold"]
+        menu = RadioMenu(moptions, pagesize=4)
+        choice = request("$(name(player))'s turn to act:", menu)
+        choice == -1 && error("Uncaught case")
+        choice == 1 && return Check()
+        choice == 2 && return Raise(input_raise_amt(table, player, ioin))
+        choice == 3 && return Fold()
+    elseif options.name == :CallRaiseFold
+        vrr = valid_raise_range(table, player)
+        call_amt = call_amount(table, player)
+        blind_str = is_blind_call(table, player) ? " (blind)" : ""
+        moptions = ["Call $(call_amt)$blind_str", "Raise [$(first(vrr)), $(last(vrr))]", "Fold"]
+        menu = RadioMenu(moptions, pagesize=4)
+        choice = request("$(name(player))'s turn to act:", menu)
+        choice == -1 && error("Uncaught case")
+        choice == 1 && return Call(table, player)
+        choice == 2 && return Raise(input_raise_amt(table, player, ioin))
+        choice == 3 && return Fold()
+    elseif options.name == :CallAllInFold
+        call_amt = call_amount(table, player)
+        all_in_amt = round_bank_roll(player)
+        blind_str = is_blind_call(table, player) ? " (blind)" : ""
+        moptions = ["Call $(call_amt)$blind_str", "Raise all-in ($(all_in_amt))", "Fold"]
+        menu = RadioMenu(moptions, pagesize=4)
+        choice = request("$(name(player))'s turn to act:", menu)
+        choice == -1 && error("Uncaught case")
+        choice == 1 && return Call(table, player)
+        choice == 2 && return AllIn(table, player)
+        choice == 3 && return Fold()
+    elseif options.name == :CallFold
+        call_amt = call_amount(table, player)
+        blind_str = is_blind_call(table, player) ? " (blind)" : ""
+        moptions = ["Call $(call_amt)$blind_str", "Fold"]
+        menu = RadioMenu(moptions, pagesize=4)
+        choice = request("$(name(player))'s turn to act:", menu)
+        choice == -1 && error("Uncaught case")
+        choice == 1 && return Call(table, player)
+        choice == 2 && return Fold()
+    else
+        error("Uncaught case")
+    end
 end
 
 quit_game(game::Game, player::Player, ioin::IO=stdin) = false

--- a/test/play.jl
+++ b/test/play.jl
@@ -34,7 +34,7 @@ end
 
 struct NoActionBot <: AbstractStrategy end
 
-TH.player_option(game::Game, player::Player{NoActionBot}, round, ::AbstractPlayerOptions) = nothing
+TH.player_option(game::Game, player::Player{NoActionBot}, round, options) = nothing
 
 @testset "Game: Play (NoActionBot)" begin
     game = QuietGame((Player(BotCheckCall(), 1), Player(NoActionBot(), 2),))

--- a/test/tester_bots.jl
+++ b/test/tester_bots.jl
@@ -9,100 +9,140 @@ const TH = TexasHoldem
 ##### BotCheckFold
 struct BotCheckFold <: AbstractStrategy end
 
-TH.player_option(game::Game, player::Player{BotCheckFold}, round, ::CheckRaiseFold) = Check()
-TH.player_option(game::Game, player::Player{BotCheckFold}, round, ::CallRaiseFold) = Fold()
-TH.player_option(game::Game, player::Player{BotCheckFold}, round, ::CallAllInFold) = Fold()
-TH.player_option(game::Game, player::Player{BotCheckFold}, round, ::CallFold) = Fold()
+function TH.player_option(game::Game, player::Player{BotCheckFold}, round, options)
+    on = options.name
+    on == :CheckRaiseFold && return Check()
+    on == :CallRaiseFold && return Fold()
+    on == :CallAllInFold && return Fold()
+    on == :CallFold && return Fold()
+end
 
 ##### BotCheckCall
 struct BotCheckCall <: AbstractStrategy end
 
-TH.player_option(game::Game, player::Player{BotCheckCall}, round, ::CheckRaiseFold) = Check()
-TH.player_option(game::Game, player::Player{BotCheckCall}, round, ::CallRaiseFold) = Call(game.table, player)
-TH.player_option(game::Game, player::Player{BotCheckCall}, round, ::CallAllInFold) = Call(game.table, player)
-TH.player_option(game::Game, player::Player{BotCheckCall}, round, ::CallFold) = Call(game.table, player)
+function TH.player_option(game::Game, player::Player{BotCheckCall}, round, options)
+    on = options.name
+    on == :CheckRaiseFold && return Check()
+    on == :CallRaiseFold && return Call(game.table, player)
+    on == :CallAllInFold && return Call(game.table, player)
+    on == :CallFold && return Call(game.table, player)
+end
 
 ##### BotFlopRaise
 struct BotFlopRaise <: AbstractStrategy end
 # Call blind / check pre-flop, raise on flop
 
-TH.player_option(game::Game, player::Player{BotFlopRaise}, round, ::CheckRaiseFold) = round == :flop ? Raise(Int(bank_roll(player)/2)) : Check()
-TH.player_option(game::Game, player::Player{BotFlopRaise}, round, ::CallRaiseFold) = Call(game.table, player)
-TH.player_option(game::Game, player::Player{BotFlopRaise}, round, ::CallAllInFold) = Call(game.table, player)
-TH.player_option(game::Game, player::Player{BotFlopRaise}, round, ::CallFold) = Call(game.table, player)
+function TH.player_option(game::Game, player::Player{BotFlopRaise}, round, options)
+    on = options.name
+    on == :CheckRaiseFold && return round == :flop ? Raise(Int(bank_roll(player)/2)) : Check()
+    on == :CallRaiseFold && return Call(game.table, player)
+    on == :CallAllInFold && return Call(game.table, player)
+    on == :CallFold && return Call(game.table, player)
+end
 
 ##### BotRaiseAllIn
 struct BotRaiseAllIn <: AbstractStrategy end
 # Call blind / check pre-flop, raise on flop
 
-TH.player_option(game::Game, player::Player{BotRaiseAllIn}, round, ::CheckRaiseFold) = Raise(last(valid_raise_range(game.table, player)))
-TH.player_option(game::Game, player::Player{BotRaiseAllIn}, round, ::CallRaiseFold) = Raise(last(valid_raise_range(game.table, player)))
-TH.player_option(game::Game, player::Player{BotRaiseAllIn}, round, ::CallAllInFold) = Raise(last(valid_raise_range(game.table, player)))
+function TH.player_option(game::Game, player::Player{BotRaiseAllIn}, round, options)
+    on = options.name
+    on == :CheckRaiseFold && return Raise(last(valid_raise_range(game.table, player)))
+    on == :CallRaiseFold && return Raise(last(valid_raise_range(game.table, player)))
+    on == :CallAllInFold && return Raise(last(valid_raise_range(game.table, player)))
+end
 
 ##### BotRaiseAlmostAllIn
 struct BotRaiseAlmostAllIn <: AbstractStrategy end
 # Call blind / check pre-flop, raise on flop
 
-TH.player_option(game::Game, player::Player{BotRaiseAlmostAllIn}, round, ::CheckRaiseFold) = Raise(Int(0.9*round_bank_roll(player)))
-TH.player_option(game::Game, player::Player{BotRaiseAlmostAllIn}, round, ::CallRaiseFold) = Raise(Int(0.9*round_bank_roll(player)))
-TH.player_option(game::Game, player::Player{BotRaiseAlmostAllIn}, round, ::CallAllInFold) = Raise(Int(0.9*round_bank_roll(player)))
+function TH.player_option(game::Game, player::Player{BotRaiseAlmostAllIn}, round, options)
+    on = options.name
+    on == :CheckRaiseFold && return Raise(Int(0.9*round_bank_roll(player)))
+    on == :CallRaiseFold && return Raise(Int(0.9*round_bank_roll(player)))
+    on == :CallAllInFold && return Raise(Int(0.9*round_bank_roll(player)))
+end
 
 ##### BotBetSB
 struct BotBetSB <: AbstractStrategy end
 
-TH.player_option(game::Game, player::Player{BotBetSB}, round, ::CheckRaiseFold) = round == :preflop ? Raise(TH.blinds(game).small) : Raise(TH.blinds(game).small)
-TH.player_option(game::Game, player::Player{BotBetSB}, round, ::CallRaiseFold) = Call(game.table, player)
-TH.player_option(game::Game, player::Player{BotBetSB}, round, ::CallFold) = Call(game.table, player)
+function TH.player_option(game::Game, player::Player{BotBetSB}, round, options)
+    on = options.name
+    on == :CheckRaiseFold && return round == :preflop ? Raise(TH.blinds(game).small) : Raise(TH.blinds(game).small)
+    on == :CallRaiseFold && return Call(game.table, player)
+    on == :CallFold && return Call(game.table, player)
+end
 
 ##### BotBetBB
 struct BotBetBB <: AbstractStrategy end
 
-TH.player_option(game::Game, player::Player{BotBetBB}, round, ::CheckRaiseFold) = round == :preflop ? Raise(2*TH.blinds(game).big) : Raise(TH.blinds(game).big)
-TH.player_option(game::Game, player::Player{BotBetBB}, round, ::CallRaiseFold) = Call(game.table, player)
-TH.player_option(game::Game, player::Player{BotBetBB}, round, ::CallFold) = Call(game.table, player)
+function TH.player_option(game::Game, player::Player{BotBetBB}, round, options)
+    on = options.name
+    on == :CheckRaiseFold && return round == :preflop ? Raise(2*TH.blinds(game).big) : Raise(TH.blinds(game).big)
+    on == :CallRaiseFold && return Call(game.table, player)
+    on == :CallFold && return Call(game.table, player)
+end
 
 ##### BotCheckOnCallRaiseFold
 struct BotCheckOnCallRaiseFold <: AbstractStrategy end
 
-TH.player_option(game::Game, player::Player{BotCheckOnCallRaiseFold}, round, ::CallRaiseFold) = Check()
+function TH.player_option(game::Game, player::Player{BotCheckOnCallRaiseFold}, round, options)
+    @assert options.name == :CallRaiseFold
+    Check()
+end
 
 ##### BotCheckOnCallAllInFold
 struct BotCheckOnCallAllInFold <: AbstractStrategy end
 
-TH.player_option(game::Game, player::Player{BotCheckOnCallAllInFold}, round, ::CallAllInFold) = Check()
+function TH.player_option(game::Game, player::Player{BotCheckOnCallAllInFold}, round, options)
+    @assert options.name == :CallAllInFold
+    Check()
+end
 
 ##### BotCheckOnCallFold
 struct BotCheckOnCallFold <: AbstractStrategy end
 
-TH.player_option(game::Game, player::Player{BotCheckOnCallFold}, round, ::CallFold) = Check()
+function TH.player_option(game::Game, player::Player{BotCheckOnCallFold}, round, options)
+    @assert options.name == :CallFold
+    Check()
+end
 
 ##### BotCallOnCheckRaiseFold
 struct BotCallOnCheckRaiseFold <: AbstractStrategy end
 
-TH.player_option(game::Game, player::Player{BotCallOnCheckRaiseFold}, round, ::CallRaiseFold) = round == :preflop ? Call(game.table, player) : Call(game.table, player)
-TH.player_option(game::Game, player::Player{BotCallOnCheckRaiseFold}, round, ::CheckRaiseFold) = Call(game.table, player)
+function TH.player_option(game::Game, player::Player{BotCallOnCheckRaiseFold}, round, options)
+    on = options.name
+    on == :CallRaiseFold && return round == :preflop ? Call(game.table, player) : Call(game.table, player)
+    on == :CheckRaiseFold && return Call(game.table, player)
+end
 
 ##### BotRaiseOnCallFold
 struct BotRaiseOnCallFold <: AbstractStrategy end
 
-TH.player_option(game::Game, player::Player{BotRaiseOnCallFold}, round, ::CallFold) = Raise(bank_roll(player))
+function TH.player_option(game::Game, player::Player{BotRaiseOnCallFold}, round, options)
+    @assert options.name == :CallFold
+    Raise(bank_roll(player))
+end
 
 ##### BotLimpAllIn
 struct BotLimpAllIn <: AbstractStrategy end
 
-TH.player_option(game::Game, player::Player{BotLimpAllIn}, round, ::AbstractPlayerOptions) = Call(game.table, player)
+function TH.player_option(game::Game, player::Player{BotLimpAllIn}, round, options)
+    Call(game.table, player)
+end
 
 ##### BotNActions
 struct BotNActions <: AbstractStrategy end
 
-function TH.player_option(game::Game, player::Player{BotNActions}, round, ::CheckRaiseFold)
-    n_check_actions[1]+=1
-    Check()
-end
-
-function TH.player_option(game::Game, player::Player{BotNActions}, round, ::CallRaiseFold)
-    n_call_actions[1]+=1
-    Call(game.table, player)
+function TH.player_option(game::Game, player::Player{BotNActions}, round, options)
+    if options.name == :CheckRaiseFold
+        n_check_actions[1]+=1
+        return Check()
+    elseif options.name == :CallRaiseFold
+        n_call_actions[1]+=1
+        return Call(game.table, player)
+    else
+        error("Uncaught case")
+    end
 end
 
 ##### BotPreFlopRaise
@@ -111,7 +151,10 @@ struct BotPreFlopRaise{FT} <: AbstractStrategy
 end
 # Call blind / check pre-flop, raise on flop
 
-TH.player_option(game::Game, player::Player{<:BotPreFlopRaise}, round, ::CheckRaiseFold) = round == :preflop ? Raise(TH.strategy(player).amt) : Check()
-TH.player_option(game::Game, player::Player{<:BotPreFlopRaise}, round, ::CallRaiseFold) = Raise(TH.strategy(player).amt)
-TH.player_option(game::Game, player::Player{<:BotPreFlopRaise}, round, ::CallAllInFold) = Call(game.table, player)
-TH.player_option(game::Game, player::Player{<:BotPreFlopRaise}, round, ::CallFold) = Call(game.table, player)
+function TH.player_option(game::Game, player::Player{<:BotPreFlopRaise}, round, options)
+    on = options.name
+    on == :CheckRaiseFold && return round == :preflop ? Raise(TH.strategy(player).amt) : Check()
+    on == :CallRaiseFold && return Raise(TH.strategy(player).amt)
+    on == :CallAllInFold && return Call(game.table, player)
+    on == :CallFold && return Call(game.table, player)
+end


### PR DESCRIPTION
Make options symbol-backed. This is needed for a type-stable api that supports fixing #244.