### PR TITLE
Fix opponent.last_to_raise assignment

### DIFF
--- a/src/player_options.jl
+++ b/src/player_options.jl
@@ -137,11 +137,11 @@ function update_given_raise!(table, player, amt)
     player.last_to_raise = true
     for opponent in players
         seat_number(opponent) == seat_number(player) && continue
+        opponent.last_to_raise = false
         not_playing(opponent) && continue
         if !all_in(opponent)
             opponent.action_required = true
         end
-        opponent.last_to_raise = false
     end
     @cinfo logger begin
         pbpai = opponents_being_put_all_in(table, player, amt)


### PR DESCRIPTION
It doesn't matter if the opponent is not active, or all in, the `opponent.last_to_raise` assignment has to come after the opponent filter (because otherwise we would undo the previous assignment) and before the subsequent filters.