### PR TITLE
Make TexasHoldem client-server friendly

### DIFF
--- a/perf/flame.jl
+++ b/perf/flame.jl
@@ -21,12 +21,12 @@ end
 import Profile
 import ProfileCanvas
 
-games = map(x->Game(players();logger=TH.ByPassLogger()), 1:100_000);
+games = map(x->Game(players();gui=TH.NoGUI(), logger=TH.ByPassLogger()), 1:100_000);
 do_work!(games) # compile first
 
 Random.seed!(1234) # reset seed
 
-games = map(x->Game(players();logger=TH.ByPassLogger()), 1:100_000);
+games = map(x->Game(players();gui=TH.NoGUI(), logger=TH.ByPassLogger()), 1:100_000);
 Profile.clear()
 prof = Profile.@profile begin
     do_work!(games)

--- a/perf/jet.jl
+++ b/perf/jet.jl
@@ -14,9 +14,9 @@ function do_work!(game)
 end
 
 # Make sure it runs without errors
-game = Game(players();logger=TH.ByPassLogger())
+game = Game(players();gui=TH.NoGUI(), logger=TH.ByPassLogger())
 do_work!(game)
 
 import JET
-game = Game(players();logger=TH.ByPassLogger())
+game = Game(players();gui=TH.NoGUI(), logger=TH.ByPassLogger())
 JET.@test_opt do_work!(game)

--- a/src/game.jl
+++ b/src/game.jl
@@ -41,7 +41,7 @@ any_actions_required(game::Game) = any_actions_required(game.table)
 round(game::Game) = round(game.table)
 move_buttons!(game) = move_buttons!(game.table)
 
-function print_round(table, round)
+function print_round(table, round::Symbol)
     table.gui isa Terminal && return nothing
     round == :preflop && @cinfo table.logger "Pre-flop!"
     round == :flop && @cinfo table.logger "Flop: $(repeat(" ", 44)) $(table.cards[1:3])"
@@ -49,7 +49,7 @@ function print_round(table, round)
     round == :river && @cinfo table.logger "River: $(repeat(" ", 43)) $(table.cards[5])"
 end
 
-function set_antes!(table::Table, round)
+function set_antes!(table::Table, round::Symbol)
     round == :preflop || return nothing
     players = players_at_table(table)
     for i in 1:length(players)
@@ -122,7 +122,7 @@ function all_bets_were_called(table::Table)
     end, players)
 end
 
-function end_preflop_actions(table::Table, player::Player, round)
+function end_preflop_actions(table::Table, player::Player, round::Symbol)
     round == :preflop || return false
     cond1 = is_big_blind(table, player)
     cond2 = checked(player)
@@ -286,7 +286,7 @@ function _play!(game::Game, ::Val{init}) where {init}
         validate_action(action, options)
 
         update_given_valid_action!(table, player, action)
-        if table.winners.declared || end_preflop_actions(table, player, round)
+        if table.winners.declared || end_preflop_actions(table, player, table.round)
             @cinfo logger "Betting finished for $(table.round)."
             @assert all_bets_were_called(table)
             reset_round_parameters!(game.table)

--- a/src/game.jl
+++ b/src/game.jl
@@ -196,14 +196,14 @@ end
 function _play!(game::Game, ::Val{init}) where {init}
     init && initialize!(game)
     while true
-        (options, flow) = play_to_options!(game)
+        (options, flow) = play_to_options!(game)::Tuple{Options,Symbol}
         if flow == :continue; continue; elseif flow == :break; break
         elseif flow == :goto_action; else; error("Uncaught case"); end
 
-        action = player_option(game, current_player(game), options)::Action
+        action = player_option(game, options)::Action
         validate_action(action, options)
 
-        update_given_valid_action!(game.table, current_player(game), action)
+        update_given_valid_action!(game, action)
         flow = check_if_game_is_over!(game)
         if flow == :continue; continue; elseif flow == :break; break
         else; error("Uncaught case"); end
@@ -252,7 +252,7 @@ function play_to_options!(game::Game)
         reset_round_parameters!(game.table)
         reset_round_orbit_state!(game)
         reset_round_bank_rolls!(table, table.round)
-        return (:none, :break)
+        return (NoOptions(), :break)
     end
     if os.i == 1
         update_gui(table)
@@ -263,12 +263,12 @@ function play_to_options!(game::Game)
             @assert all_bets_were_called(table)
             reset_round_parameters!(game.table)
             if table.round == :river
-                return (:none, :break)
+                return (NoOptions(), :break)
             else
                 table.round = next_round(table.round)
                 reset_round_orbit_state!(game)
                 reset_round_bank_rolls!(table, table.round)
-                return (:none, :continue)
+                return (NoOptions(), :continue)
             end
         end
         set_play_out_game!(table)
@@ -283,17 +283,17 @@ function play_to_options!(game::Game)
         @assert all_bets_were_called(table)
         reset_round_parameters!(game.table)
         if table.round == :river
-            return (:none, :break)
+            return (NoOptions(), :break)
         else
             table.round = next_round(table.round)
             reset_round_orbit_state!(game)
             reset_round_bank_rolls!(table, table.round)
-            return (:none, :continue)
+            return (NoOptions(), :continue)
         end
     end
     if all_in(player) || not_playing(player)
         update_orbit_state!(game)
-        return (:none, :continue)
+        return (NoOptions(), :continue)
     end
     @cdebug logger "$(name(player))'s turn to act"
 

--- a/src/player_options.jl
+++ b/src/player_options.jl
@@ -273,13 +273,6 @@ and has one of the following names
 """
 function player_option end
 
-function player_option(game::Game, player::Player)
-    options = get_options(game, player)
-    action = player_option(game, player, options)::Action
-    validate_action(action, options)
-    return action
-end
-
 # By default, forward to `player_option` with
 # game round:
 # player_option(game::Game, options) =

--- a/src/player_options.jl
+++ b/src/player_options.jl
@@ -21,6 +21,14 @@ struct Options
 end
 
 """
+    NoOptions
+
+The option when a player has no options (e.g.,
+they are all-in).
+"""
+NoOptions() = Options(:NoOptions)
+
+"""
     CheckRaiseFold
 
 The option when a player is only able to
@@ -187,6 +195,9 @@ function an_opponent_can_call_a_raise(table::Table, player::Player)
     return occr
 end
 
+update_given_valid_action!(game::Game, action::Action) =
+    update_given_valid_action!(game.table, current_player(game), action)
+
 update_given_valid_action!(game::Game, player::Player, action::Action) =
     update_given_valid_action!(game.table, player, action)
 function update_given_valid_action!(table::Table, player::Player, action::Action)
@@ -272,6 +283,9 @@ and has one of the following names
  - `options.name == CallFold`
 """
 function player_option end
+
+player_option(game::Game, options::Options) =
+    player_option(game, current_player(game), options)
 
 # By default, forward to `player_option` with
 # game round:

--- a/src/terminal/ui.jl
+++ b/src/terminal/ui.jl
@@ -31,7 +31,7 @@ function update_gui(io::IO, table::Table, ::Terminal, pov_player)
     gui = table.gui
     clear_screen(io)
     # Print pot info
-    println(io, "       Round: $(nameof(typeof(table.round)))")
+    println(io, "       Round: $(table.round)")
     println(io, "       Chips in pot: $(pot(table.transactions))")
     for i in 1:2; println(io); end
     ocs = if table.winners.declared


### PR DESCRIPTION
Closes #244.

This PR simplifies `_play!` to look like this:

```julia
function _play!(game::Game, ::Val{init}) where {init}
    init && initialize!(game)
    while true
        (options, flow) = play_to_options!(game)::Tuple{Options,Symbol}
        if flow == :continue; continue; elseif flow == :break; break
        elseif flow == :goto_action; else; error("Uncaught case"); end

        action = player_option(game, options)::Action
        validate_action(action, options)

        update_given_valid_action!(game, action)
        flow = check_if_game_is_over!(game)
        if flow == :continue; continue; elseif flow == :break; break
        else; error("Uncaught case"); end
    end
    distribute_winnings!(game)
    game.table.winners.declared = true
    post_game_procedure(game)
    return any_quit_game(game)
end
```
which is much more client-server friendly (and more user-friendly for reinforcement learning).

Performance has degraded by no more than 15% since we started all of this refactoring. I'm sure it's recoverable.